### PR TITLE
70-task-worker-pools-for-each-job-type

### DIFF
--- a/cmd/schedulers/condition/main.go
+++ b/cmd/schedulers/condition/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/condition/api"
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/condition/client"
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/condition/config"
+	"github.com/trigg3rX/triggerx-backend/internal/schedulers/condition/metrics"
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/condition/scheduler"
 	"github.com/trigg3rX/triggerx-backend/pkg/logging"
 )
@@ -23,6 +24,9 @@ func main() {
 	if err := config.Init(); err != nil {
 		panic(fmt.Sprintf("Failed to initialize config: %v", err))
 	}
+
+	// Start metrics collection
+	metrics.StartMetricsCollection()
 
 	// Initialize logger
 	logConfig := logging.LoggerConfig{

--- a/cmd/schedulers/event/main.go
+++ b/cmd/schedulers/event/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/event/api"
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/event/client"
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/event/config"
+	"github.com/trigg3rX/triggerx-backend/internal/schedulers/event/metrics"
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/event/scheduler"
 	"github.com/trigg3rX/triggerx-backend/pkg/logging"
 )
@@ -23,6 +24,9 @@ func main() {
 	if err := config.Init(); err != nil {
 		panic(fmt.Sprintf("Failed to initialize config: %v", err))
 	}
+
+	// Start metrics collection
+	metrics.StartMetricsCollection()
 
 	// Initialize logger
 	logConfig := logging.LoggerConfig{

--- a/cmd/schedulers/time/main.go
+++ b/cmd/schedulers/time/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/time/api"
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/time/client"
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/time/config"
+	"github.com/trigg3rX/triggerx-backend/internal/schedulers/time/metrics"
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/time/scheduler"
 	"github.com/trigg3rX/triggerx-backend/pkg/logging"
 )
@@ -23,6 +24,9 @@ func main() {
 	if err := config.Init(); err != nil {
 		panic(fmt.Sprintf("Failed to initialize config: %v", err))
 	}
+
+	// Start metrics collection
+	metrics.StartMetricsCollection()
 
 	// Initialize logger
 	logConfig := logging.LoggerConfig{

--- a/internal/schedulers/condition/config/config.go
+++ b/internal/schedulers/condition/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/joho/godotenv"
 
@@ -14,6 +15,7 @@ type Config struct {
 	databaseHostPort string
 	schedulerRPCPort string
 	dbServerURL      string
+	maxWorkers       int
 }
 
 var cfg Config
@@ -24,12 +26,19 @@ func Init() error {
 		return fmt.Errorf("error loading .env file: %w", err)
 	}
 
+	maxWorkersStr := env.GetEnv("MAX_WORKERS", "100")
+	maxWorkers, err := strconv.Atoi(maxWorkersStr)
+	if err != nil {
+		maxWorkers = 100 // fallback to default
+	}
+
 	cfg = Config{
 		devMode:          env.GetEnv("DEV_MODE", "false") == "true",
 		databaseHost:     env.GetEnv("DATABASE_HOST", "localhost"),
 		databaseHostPort: env.GetEnv("DATABASE_HOST_PORT", "9042"),
 		schedulerRPCPort: env.GetEnv("CONDITION_SCHEDULER_RPC_PORT", "9005"), // Different port from event scheduler
 		dbServerURL:      env.GetEnv("DATABASE_RPC_URL", "http://localhost:9002"),
+		maxWorkers:       maxWorkers,
 	}
 
 	return nil
@@ -58,4 +67,9 @@ func GetSchedulerRPCPort() string {
 // GetDBServerURL returns the database server URL
 func GetDBServerURL() string {
 	return cfg.dbServerURL
+}
+
+// GetMaxWorkers returns the maximum number of concurrent workers allowed
+func GetMaxWorkers() int {
+	return cfg.maxWorkers
 }

--- a/internal/schedulers/event/config/config.go
+++ b/internal/schedulers/event/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/joho/godotenv"
 
@@ -14,6 +15,7 @@ type Config struct {
 	databaseHostPort string
 	schedulerRPCPort string
 	dbServerURL      string
+	maxWorkers       int
 	// Chain RPC URLs
 	opSepoliaRPC   string
 	baseSepoliaRPC string
@@ -28,12 +30,19 @@ func Init() error {
 		return fmt.Errorf("error loading .env file: %w", err)
 	}
 
+	maxWorkersStr := env.GetEnv("MAX_WORKERS", "100")
+	maxWorkers, err := strconv.Atoi(maxWorkersStr)
+	if err != nil {
+		maxWorkers = 100 // fallback to default
+	}
+
 	cfg = Config{
 		devMode:          env.GetEnv("DEV_MODE", "false") == "true",
 		databaseHost:     env.GetEnv("DATABASE_HOST", "localhost"),
 		databaseHostPort: env.GetEnv("DATABASE_HOST_PORT", "9042"),
 		schedulerRPCPort: env.GetEnv("SCHEDULER_RPC_PORT", "9004"),
 		dbServerURL:      env.GetEnv("DATABASE_RPC_URL", "http://localhost:9002"),
+		maxWorkers:       maxWorkers,
 		// Chain RPC URLs with default values
 		opSepoliaRPC:   env.GetEnv("OP_SEPOLIA_RPC_URL", "https://sepolia.optimism.io"),
 		baseSepoliaRPC: env.GetEnv("BASE_SEPOLIA_RPC_URL", "https://sepolia.base.org"),
@@ -90,4 +99,9 @@ func GetBaseSepoliaRPC() string {
 // GetEthSepoliaRPC returns the Ethereum Sepolia RPC URL
 func GetEthSepoliaRPC() string {
 	return cfg.ethSepoliaRPC
+}
+
+// GetMaxWorkers returns the maximum number of concurrent workers allowed
+func GetMaxWorkers() int {
+	return cfg.maxWorkers
 }

--- a/internal/schedulers/time/config/config.go
+++ b/internal/schedulers/time/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/joho/godotenv"
 
@@ -14,6 +15,7 @@ type Config struct {
 	databaseHostPort string
 	schedulerRPCPort string
 	dbServerURL      string
+	maxWorkers       int
 }
 
 var cfg Config
@@ -24,12 +26,19 @@ func Init() error {
 		return fmt.Errorf("error loading .env file: %w", err)
 	}
 
+	maxWorkersStr := env.GetEnv("MAX_WORKERS", "10")
+	maxWorkers, err := strconv.Atoi(maxWorkersStr)
+	if err != nil {
+		maxWorkers = 10 // fallback to default
+	}
+
 	cfg = Config{
 		devMode:          env.GetEnvBool("DEV_MODE", false),
 		databaseHost:     env.GetEnv("DATABASE_HOST", "localhost"),
 		databaseHostPort: env.GetEnv("DATABASE_HOST_PORT", "9042"),
 		schedulerRPCPort: env.GetEnv("SCHEDULER_RPC_PORT", "9004"),
 		dbServerURL:      env.GetEnv("DATABASE_RPC_URL", "http://localhost:9002"),
+		maxWorkers:       maxWorkers,
 	}
 
 	return nil
@@ -58,4 +67,9 @@ func GetSchedulerRPCPort() string {
 // GetDBServerURL returns the database server URL
 func GetDBServerURL() string {
 	return cfg.dbServerURL
+}
+
+// GetMaxWorkers returns the maximum number of workers
+func GetMaxWorkers() int {
+	return cfg.maxWorkers
 }


### PR DESCRIPTION
# Pull Request

## Related Issues
#70 
Closed #70 

## Implementation Details
Updated the configs of each scheduler to include number of workers, 10 by default.