### PR TITLE
174 feature add imua for the registration of keepers in whitelist form

### DIFF
--- a/internal/dbserver/handlers/apikey_handlers.go
+++ b/internal/dbserver/handlers/apikey_handlers.go
@@ -34,7 +34,7 @@ func (h *Handler) CreateApiKey(c *gin.Context) {
 	trackDBOp := metrics.TrackDBOperation("read", "apikey_data")
 	existingKey, err := h.apiKeysRepository.GetApiKeyDataByOwner(req.Owner)
 	trackDBOp(err)
-	if err != nil {
+	if err != nil && err.Error() != "owner not found" {
 		h.logger.Errorf("[CreateApiKey] Database error: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
 		return

--- a/internal/dbserver/handlers/job_create.go
+++ b/internal/dbserver/handlers/job_create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/trigg3rX/triggerx-backend/internal/dbserver/metrics"
 	"github.com/trigg3rX/triggerx-backend/internal/dbserver/types"
 	"github.com/trigg3rX/triggerx-backend/pkg/parser"
-	commonTypes"github.com/trigg3rX/triggerx-backend/pkg/types"
+	commonTypes "github.com/trigg3rX/triggerx-backend/pkg/types"
 )
 
 func (h *Handler) CreateJobData(c *gin.Context) {
@@ -103,6 +103,7 @@ func (h *Handler) CreateJobData(c *gin.Context) {
 			Status:            "pending",
 			JobCostPrediction: tempJobs[i].JobCostPrediction,
 			Timezone:          tempJobs[i].Timezone,
+			IsImua:            tempJobs[i].IsImua,
 		}
 
 		// Track job creation
@@ -205,12 +206,12 @@ func (h *Handler) CreateJobData(c *gin.Context) {
 				DynamicArgumentsScriptUrl: tempJobs[i].DynamicArgumentsScriptUrl,
 			}
 			scheduleConditionJobData.EventWorkerData = commonTypes.EventWorkerData{
-				JobID:                     jobID,
-				ExpirationTime:            expirationTime,
-				Recurring:                 tempJobs[i].Recurring,
-				TriggerChainID:            tempJobs[i].TriggerChainID,
-				TriggerContractAddress:    tempJobs[i].TriggerContractAddress,
-				TriggerEvent:              tempJobs[i].TriggerEvent,
+				JobID:                  jobID,
+				ExpirationTime:         expirationTime,
+				Recurring:              tempJobs[i].Recurring,
+				TriggerChainID:         tempJobs[i].TriggerChainID,
+				TriggerContractAddress: tempJobs[i].TriggerContractAddress,
+				TriggerEvent:           tempJobs[i].TriggerEvent,
 			}
 			h.logger.Infof("[CreateJobData] Successfully created event-based job %d for event %s on contract %s",
 				jobID, eventJobData.TriggerEvent, eventJobData.TriggerContractAddress)
@@ -258,14 +259,14 @@ func (h *Handler) CreateJobData(c *gin.Context) {
 				DynamicArgumentsScriptUrl: tempJobs[i].DynamicArgumentsScriptUrl,
 			}
 			scheduleConditionJobData.ConditionWorkerData = commonTypes.ConditionWorkerData{
-				JobID:                     jobID,
-				ExpirationTime:            expirationTime,
-				Recurring:                 tempJobs[i].Recurring,
-				ConditionType:             tempJobs[i].ConditionType,
-				UpperLimit:                tempJobs[i].UpperLimit,
-				LowerLimit:                tempJobs[i].LowerLimit,
-				ValueSourceType:           tempJobs[i].ValueSourceType,
-				ValueSourceUrl:            tempJobs[i].ValueSourceUrl,
+				JobID:           jobID,
+				ExpirationTime:  expirationTime,
+				Recurring:       tempJobs[i].Recurring,
+				ConditionType:   tempJobs[i].ConditionType,
+				UpperLimit:      tempJobs[i].UpperLimit,
+				LowerLimit:      tempJobs[i].LowerLimit,
+				ValueSourceType: tempJobs[i].ValueSourceType,
+				ValueSourceUrl:  tempJobs[i].ValueSourceUrl,
 			}
 			h.logger.Infof("[CreateJobData] Successfully created condition-based job %d with condition type %s (limits: %f-%f)",
 				jobID, conditionJobData.ConditionType, conditionJobData.LowerLimit, conditionJobData.UpperLimit)

--- a/internal/dbserver/handlers/keeper_create.go
+++ b/internal/dbserver/handlers/keeper_create.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/trigg3rX/triggerx-backend/internal/dbserver/metrics"
@@ -80,4 +81,45 @@ func (h *Handler) CreateKeeperData(c *gin.Context) {
 
 	h.logger.Infof("[CreateKeeperData] Successfully created keeper with ID: %d", currentKeeperID)
 	c.JSON(http.StatusCreated, gin.H{"keeper_id": currentKeeperID})
+}
+
+func (h *Handler) CreateKeeperDataGoogleForm(c *gin.Context) {
+	var keeperData types.GoogleFormCreateKeeperData
+	if err := c.ShouldBindJSON(&keeperData); err != nil {
+		h.logger.Errorf("[CreateKeeperDataGoogleForm] Error decoding request body: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request format", "code": "INVALID_REQUEST"})
+		return
+	}
+
+	keeperData.KeeperAddress = strings.ToLower(keeperData.KeeperAddress)
+
+	trackDBOp := metrics.TrackDBOperation("read", "keeper_data")
+	existingKeeperID, err := h.keeperRepository.CheckKeeperExistsByAddress(keeperData.KeeperAddress)
+	trackDBOp(err)
+	if err != nil {
+		h.logger.Errorf("[CreateKeeperDataGoogleForm] Database error while checking keeper existence: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Database error while checking keeper status", "code": "DB_ERROR"})
+		return
+	}
+
+	var status string
+	var keeperID int64
+	if existingKeeperID != 0 {
+		status = "existing"
+		keeperID = existingKeeperID
+	} else {
+		status = "created"
+	}
+
+	trackDBOp = metrics.TrackDBOperation("create", "keeper_data")
+	keeperID, err = h.keeperRepository.CreateOrUpdateKeeperFromGoogleForm(keeperData)
+	trackDBOp(err)
+	if err != nil {
+		h.logger.Errorf("[CreateKeeperDataGoogleForm] Error creating/updating keeper data: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create/update keeper", "code": "KEEPER_CREATION_ERROR"})
+		return
+	}
+
+	h.logger.Infof("[CreateKeeperDataGoogleForm] Successfully processed keeper with ID: %d", keeperID)
+	c.JSON(http.StatusCreated, gin.H{"keeper_id": keeperID, "status": status})
 }

--- a/internal/dbserver/handlers/keeper_create.go
+++ b/internal/dbserver/handlers/keeper_create.go
@@ -103,16 +103,14 @@ func (h *Handler) CreateKeeperDataGoogleForm(c *gin.Context) {
 	}
 
 	var status string
-	var keeperID int64
 	if existingKeeperID != 0 {
 		status = "existing"
-		keeperID = existingKeeperID
 	} else {
 		status = "created"
 	}
 
 	trackDBOp = metrics.TrackDBOperation("create", "keeper_data")
-	keeperID, err = h.keeperRepository.CreateOrUpdateKeeperFromGoogleForm(keeperData)
+	keeperID, err := h.keeperRepository.CreateOrUpdateKeeperFromGoogleForm(keeperData)
 	trackDBOp(err)
 	if err != nil {
 		h.logger.Errorf("[CreateKeeperDataGoogleForm] Error creating/updating keeper data: %v", err)

--- a/internal/dbserver/handlers/keeperhandlers_test.go
+++ b/internal/dbserver/handlers/keeperhandlers_test.go
@@ -136,7 +136,7 @@ func setupTestKeeperHandler() (*Handler, *MockKeeperRepository, *MockTaskReposit
 	mockTaskRepo := new(MockTaskRepository)
 
 	handler := &Handler{
-		keeperRepository: mockKeeperRepo,
+		keeperRepository: mockKeeperRepo, // This will cause a compile error if MockKeeperRepository does not implement all methods of KeeperRepository
 		taskRepository:   mockTaskRepo,
 		logger:           &MockLogger{},
 	}
@@ -675,4 +675,23 @@ func TestGetKeeperCommunicationInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Add missing methods to MockKeeperRepository
+func (m *MockKeeperRepository) CheckKeeperExistsByAddress(address string) (int64, error) {
+	args := m.Called(address)
+	var defaultReturnInt64 int64 = 0
+	if args.Get(0) == nil {
+		return defaultReturnInt64, args.Error(1)
+	}
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockKeeperRepository) CreateOrUpdateKeeperFromGoogleForm(keeperData types.GoogleFormCreateKeeperData) (int64, error) {
+	args := m.Called(keeperData)
+	var defaultReturnInt64 int64 = 0
+	if args.Get(0) == nil {
+		return defaultReturnInt64, args.Error(1)
+	}
+	return args.Get(0).(int64), args.Error(1)
 }

--- a/internal/dbserver/middleware/apikeyauth.go
+++ b/internal/dbserver/middleware/apikeyauth.go
@@ -125,8 +125,8 @@ func (a *ApiKeyAuth) KeeperMiddleware() gin.HandlerFunc {
 }
 
 func (a *ApiKeyAuth) getApiKey(key string) (*types.ApiKey, error) {
-	query := `SELECT key, owner, isActive, rateLimit, lastUsed, createdAt 
-			  FROM triggerx.apikeys WHERE key = ? AND isActive = ? ALLOW FILTERING`
+	query := `SELECT key, owner, is_active, rate_limit, last_used, created_at 
+			  FROM triggerx.apikeys WHERE key = ? AND is_active = ? ALLOW FILTERING`
 
 	var apiKey types.ApiKey
 
@@ -148,7 +148,7 @@ func (a *ApiKeyAuth) getApiKey(key string) (*types.ApiKey, error) {
 }
 
 func (a *ApiKeyAuth) updateLastUsed(key string) {
-	query := `UPDATE triggerx.apikeys SET lastUsed = ? WHERE key = ? ALLOW FILTERING`
+	query := `UPDATE triggerx.apikeys SET last_used = ? WHERE key = ? ALLOW FILTERING`
 
 	if err := a.db.Session().Query(query, time.Now().UTC(), key).Exec(); err != nil {
 		a.logger.Errorf("Failed to update last used timestamp: %v", err)

--- a/internal/dbserver/repository/job_repository.go
+++ b/internal/dbserver/repository/job_repository.go
@@ -39,7 +39,7 @@ func (r *jobRepository) CreateNewJob(job *types.JobData) (int64, error) {
 
 	err = r.db.Session().Query(queries.CreateJobDataQuery,
 		lastJobID+1, job.JobTitle, job.TaskDefinitionID, job.UserID, job.LinkJobID, job.ChainStatus,
-		job.Custom, job.TimeFrame, job.Recurring, job.Status, job.JobCostPrediction, time.Now(), time.Now(), job.Timezone).Exec()
+		job.Custom, job.TimeFrame, job.Recurring, job.Status, job.JobCostPrediction, time.Now(), time.Now(), job.Timezone, job.IsImua).Exec()
 
 	if err != nil {
 		return -1, err
@@ -89,7 +89,7 @@ func (r *jobRepository) GetJobByID(jobID int64) (*types.JobData, error) {
 		&jobData.LinkJobID, &jobData.ChainStatus, &jobData.Custom, &jobData.TimeFrame,
 		&jobData.Recurring, &jobData.Status, &jobData.JobCostPrediction, &jobData.JobCostActual,
 		&jobData.TaskIDs, &jobData.CreatedAt, &jobData.UpdatedAt, &jobData.LastExecutedAt,
-		&jobData.Timezone)
+		&jobData.Timezone, &jobData.IsImua)
 
 	if err != nil {
 		return nil, err

--- a/internal/dbserver/repository/queries/job_queries.go
+++ b/internal/dbserver/repository/queries/job_queries.go
@@ -8,9 +8,9 @@ const (
 			INSERT INTO triggerx.job_data (
 				job_id, job_title, task_definition_id, user_id, link_job_id, chain_status,
 				custom, time_frame, recurring, status, job_cost_prediction,
-				created_at, updated_at, timezone
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-	// 14 values to be inserted, so 14 ?s
+				created_at, updated_at, timezone, is_imua
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	// 15 values to be inserted, so 15 ?s
 )
 
 // Write Queries
@@ -37,7 +37,7 @@ const (
 	GetJobDataByJobIDQuery = `
 			SELECT job_id, job_title, task_definition_id, user_id, link_job_id, chain_status,
 				custom, time_frame, recurring, status, job_cost_prediction, job_cost_actual,
-				task_ids, created_at, updated_at, last_executed_at, timezone
+				task_ids, created_at, updated_at, last_executed_at, timezone, is_imua
 			FROM triggerx.job_data 
 			WHERE job_id = ?`
 

--- a/internal/dbserver/repository/queries/keeper_queries.go
+++ b/internal/dbserver/repository/queries/keeper_queries.go
@@ -9,6 +9,17 @@ const (
 				keeper_id, keeper_name, keeper_address, rewards_booster,
 				keeper_points, whitelisted, email_id
 			) VALUES (?, ?, ?, ?, ?, ?, ?)`
+
+	CreateNewKeeperFromGoogleFormQuery = `
+			INSERT INTO triggerx.keeper_data (
+				keeper_id, keeper_name, keeper_address,
+				rewards_address, email_id, on_imua
+			) VALUES (?, ?, ?, ?, ?, ?)`
+
+	UpdateKeeperFromGoogleFormQuery = `
+			UPDATE triggerx.keeper_data SET 
+				keeper_name = ?, keeper_address = ?, rewards_address = ?, email_id = ?, on_imua = ?
+			WHERE keeper_id = ?`
 )
 
 // Update Queries
@@ -54,56 +65,56 @@ const (
 // Read Queries
 const (
 	GetKeeperDataByIDQuery = `
-			SELECT keeper_id, keeper_name, keeper_address, consensus_address, registered_tx, operator_id,
-				rewards_address, rewards_booster, voting_power, keeper_points, connection_address,
-				peer_id, strategies, whitelisted, registered, online, version, no_executed_tasks,
-				no_attested_tasks, chat_id, email_id, last_checked_in
-			FROM triggerx.keeper_data 
-			WHERE keeper_id = ?`
+		SELECT keeper_id, keeper_name, keeper_address, consensus_address, registered_tx, operator_id,
+			rewards_address, rewards_booster, voting_power, keeper_points, connection_address,
+			peer_id, strategies, whitelisted, registered, online, version, no_executed_tasks,
+			no_attested_tasks, chat_id, email_id, last_checked_in, on_imua
+		FROM triggerx.keeper_data 
+		WHERE keeper_id = ?`
 
 	GetKeeperIDByAddressQuery = `
-			SELECT keeper_id
-			FROM triggerx.keeper_data 
-			WHERE keeper_address = ? ALLOW FILTERING`
+		SELECT keeper_id
+		FROM triggerx.keeper_data 
+		WHERE keeper_address = ? ALLOW FILTERING`
 
 	GetKeeperIDByOperatorIDQuery = `
-			SELECT keeper_id
-			FROM triggerx.keeper_data 
-			WHERE operator_id = ? ALLOW FILTERING`
+		SELECT keeper_id
+		FROM triggerx.keeper_data 
+		WHERE operator_id = ? ALLOW FILTERING`
 
 	GetKeeperIDByNameQuery = `
-			SELECT keeper_id
-			FROM triggerx.keeper_data 
-			WHERE keeper_name = ? ALLOW FILTERING`
+		SELECT keeper_id
+		FROM triggerx.keeper_data 
+		WHERE keeper_name = ? ALLOW FILTERING`
 
 	GetKeeperLeaderboardQuery = `
-			SELECT keeper_id, keeper_address, keeper_name, no_executed_tasks, no_attested_tasks, keeper_points 
-			FROM triggerx.keeper_data 
-			WHERE registered = true AND whitelisted = true ALLOW FILTERING`
+		SELECT keeper_id, keeper_address, keeper_name, no_executed_tasks, no_attested_tasks, keeper_points 
+		FROM triggerx.keeper_data 
+		WHERE registered = true AND whitelisted = true ALLOW FILTERING`
 
 	GetKeeperLeaderboardByAddressQuery = `
-			SELECT keeper_id, keeper_address, keeper_name, no_executed_tasks, no_attested_tasks, keeper_points 
-			FROM triggerx.keeper_data 
-			WHERE registered = true AND keeper_address = ? ALLOW FILTERING`
+		SELECT keeper_id, keeper_address, keeper_name, no_executed_tasks, no_attested_tasks, keeper_points 
+		FROM triggerx.keeper_data 
+		WHERE registered = true AND keeper_address = ? ALLOW FILTERING`
 
 	GetKeeperLeaderboardByNameQuery = `
-			SELECT keeper_id, keeper_address, keeper_name, no_executed_tasks, no_attested_tasks, keeper_points 
-			FROM triggerx.keeper_data 
-			WHERE registered = true AND keeper_name = ? ALLOW FILTERING`
+		SELECT keeper_id, keeper_address, keeper_name, no_executed_tasks, no_attested_tasks, keeper_points 
+		FROM triggerx.keeper_data 
+		WHERE registered = true AND keeper_name = ? ALLOW FILTERING`
 
 	GetKeeperAsPerformersQuery = `
-			SELECT keeper_id, keeper_address 
-			FROM triggerx.keeper_data 
-			WHERE whitelisted = true AND registered = true ALLOW FILTERING`
+		SELECT keeper_id, keeper_address 
+		FROM triggerx.keeper_data 
+		WHERE whitelisted = true AND registered = true ALLOW FILTERING`
 
 	GetKeeperTaskCountByIDQuery = `
-			SELECT no_executed_tasks FROM triggerx.keeper_data WHERE keeper_id = ?`
+		SELECT no_executed_tasks FROM triggerx.keeper_data WHERE keeper_id = ?`
 
 	GetKeeperPointsByIDQuery = `
-			SELECT keeper_points FROM triggerx.keeper_data WHERE keeper_id = ?`
+		SELECT keeper_points FROM triggerx.keeper_data WHERE keeper_id = ?`
 
 	GetKeeperCommunicationInfoQuery = `
-			SELECT chat_id, keeper_name, email_id 
-			FROM triggerx.keeper_data 
-			WHERE keeper_id = ?`
+		SELECT chat_id, keeper_name, email_id 
+		FROM triggerx.keeper_data 
+		WHERE keeper_id = ?`
 )

--- a/internal/dbserver/repository/queries/task_queries.go
+++ b/internal/dbserver/repository/queries/task_queries.go
@@ -7,8 +7,8 @@ const (
 	// Schedulers will Create Task Data in DB before Passing the task to the Performer
 	CreateTaskDataQuery = `
         INSERT INTO triggerx.task_data (
-            task_id, job_id, task_definition_id, created_at
-        ) VALUES (?, ?, ?, ?)`
+            task_id, job_id, task_definition_id, created_at, is_imua
+        ) VALUES (?, ?, ?, ?, ?)`
 )
 
 // Update Queries
@@ -46,7 +46,7 @@ const (
                task_opx_cost, execution_timestamp, execution_tx_hash, task_performer_id, 
 			   proof_of_task, task_attester_ids,
 			   tp_signature, ta_signature, task_submission_tx_hash,
-			   is_successful, task_status
+			   is_successful, task_status, is_imua
         FROM triggerx.task_data
         WHERE task_id = ?`
 

--- a/internal/dbserver/repository/task_repository.go
+++ b/internal/dbserver/repository/task_repository.go
@@ -37,7 +37,7 @@ func (r *taskRepository) CreateTaskDataInDB(task *types.CreateTaskDataRequest) (
 	if err != nil {
 		return -1, errors.New("error getting max task ID")
 	}
-	err = r.db.Session().Query(queries.CreateTaskDataQuery, maxTaskID+1, task.JobID, task.TaskDefinitionID, time.Now()).Exec()
+	err = r.db.Session().Query(queries.CreateTaskDataQuery, maxTaskID+1, task.JobID, task.TaskDefinitionID, time.Now(), task.IsImua).Exec()
 	if err != nil {
 		return -1, errors.New("error creating task data")
 	}
@@ -78,7 +78,7 @@ func (r *taskRepository) UpdateTaskNumberAndStatus(taskID int64, taskNumber int6
 
 func (r *taskRepository) GetTaskDataByID(taskID int64) (types.TaskData, error) {
 	var task types.TaskData
-	err := r.db.Session().Query(queries.GetTaskDataByIDQuery, taskID).Scan(&task.TaskID, &task.TaskNumber, &task.JobID, &task.TaskDefinitionID, &task.CreatedAt, &task.TaskOpXCost, &task.ExecutionTimestamp, &task.ExecutionTxHash, &task.TaskPerformerID, &task.ProofOfTask, &task.TaskAttesterIDs, &task.TpSignature, &task.TaSignature, &task.TaskSubmissionTxHash, &task.IsSuccessful, &task.TaskStatus)
+	err := r.db.Session().Query(queries.GetTaskDataByIDQuery, taskID).Scan(&task.TaskID, &task.TaskNumber, &task.JobID, &task.TaskDefinitionID, &task.CreatedAt, &task.TaskOpXCost, &task.ExecutionTimestamp, &task.ExecutionTxHash, &task.TaskPerformerID, &task.ProofOfTask, &task.TaskAttesterIDs, &task.TpSignature, &task.TaSignature, &task.TaskSubmissionTxHash, &task.IsSuccessful, &task.TaskStatus, &task.IsImua)
 	if err != nil {
 		return types.TaskData{}, errors.New("error getting task data by ID")
 	}

--- a/internal/dbserver/server.go
+++ b/internal/dbserver/server.go
@@ -166,6 +166,7 @@ func (s *Server) RegisterRoutes(router *gin.Engine) {
 	api.GET("/tasks/job/:job_id", handler.GetTasksByJobID)
 
 	api.POST("/keepers", s.validator.GinMiddleware(), handler.CreateKeeperData)
+	api.POST("/keepers/form", s.validator.GinMiddleware(), handler.CreateKeeperDataGoogleForm)
 	api.GET("/keepers/performers", handler.GetPerformers)
 	api.GET("/keepers/:id", handler.GetKeeperData)
 	api.POST("/keepers/:id/increment-tasks", handler.IncrementKeeperTaskCount)

--- a/internal/dbserver/types/job_types.go
+++ b/internal/dbserver/types/job_types.go
@@ -23,6 +23,7 @@ type JobData struct {
 	UpdatedAt         time.Time `json:"updated_at"`
 	LastExecutedAt    time.Time `json:"last_executed_at"`
 	Timezone          string    `json:"timezone"`
+	IsImua            bool      `json:"is_imua"`
 }
 
 // JobResponse is a unified type for different job types to be sent to the frontend
@@ -95,6 +96,8 @@ type CreateJobData struct {
 	ArgType                   int      `json:"arg_type" validate:"required"`
 	Arguments                 []string `json:"arguments" validate:"omitempty"`
 	DynamicArgumentsScriptUrl string   `json:"dynamic_arguments_script_url,omitempty" validate:"omitempty,ipfs_url"`
+
+	IsImua bool `json:"is_imua"`
 }
 
 type CreateJobResponse struct {

--- a/internal/dbserver/types/keeper_types.go
+++ b/internal/dbserver/types/keeper_types.go
@@ -25,12 +25,22 @@ type KeeperData struct {
 	ChatID            int64     `json:"chat_id"`
 	EmailID           string    `json:"email_id"`
 	LastCheckedIn     time.Time `json:"last_checked_in"`
+	OnImua            bool      `json:"on_imua"`
 }
 
 type CreateKeeperData struct {
 	KeeperName    string `json:"keeper_name"`
 	KeeperAddress string `json:"keeper_address"`
 	EmailID       string `json:"email_id"`
+}
+
+// Create New Keeper from Google Form (google script)
+type GoogleFormCreateKeeperData struct {
+	KeeperAddress  string `json:"keeper_address" validate:"required,ethereum_address"`
+	RewardsAddress string `json:"rewards_address" validate:"required,ethereum_address"`
+	KeeperName     string `json:"keeper_name" validate:"required,min=3,max=50"`
+	EmailID        string `json:"email_id" validate:"required,email"`
+	OnImua         bool   `json:"on_imua"`
 }
 
 type UpdateKeeperChatIDRequest struct {

--- a/internal/dbserver/types/task_types.go
+++ b/internal/dbserver/types/task_types.go
@@ -19,11 +19,13 @@ type TaskData struct {
 	TaskSubmissionTxHash string    `json:"task_submission_tx_hash"`
 	IsSuccessful         bool      `json:"is_successful"`
 	TaskStatus           string    `json:"task_status"`
+	IsImua               bool      `json:"is_imua"`
 }
 
 type CreateTaskDataRequest struct {
 	JobID            int64 `json:"job_id" validate:"required"`
 	TaskDefinitionID int   `json:"task_definition_id" validate:"required"`
+	IsImua           bool  `json:"is_imua"`
 }
 
 type UpdateTaskExecutionDataRequest struct {

--- a/internal/keeper/core/validation/utils.go
+++ b/internal/keeper/core/validation/utils.go
@@ -41,7 +41,7 @@ func (v *TaskValidator) getBlockTimestamp(receipt *ethtypes.Receipt, rpcURL stri
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to call eth_getBlockReceipts: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)

--- a/internal/schedulers/condition/scheduler/schedule.go
+++ b/internal/schedulers/condition/scheduler/schedule.go
@@ -376,7 +376,7 @@ func (s *ConditionBasedScheduler) submitTaskToRedisAPI(request SchedulerTaskRequ
 			"error", err)
 		return false, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Parse response
 	var apiResponse RedisAPIResponse

--- a/internal/schedulers/time/scheduler/schedule.go
+++ b/internal/schedulers/time/scheduler/schedule.go
@@ -188,7 +188,7 @@ func (s *TimeBasedScheduler) submitBatchToRedis(request SchedulerTaskRequest, pr
 			"error", err)
 		return false
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Parse response
 	var apiResponse RedisAPIResponse

--- a/pkg/client/aggregator/task.go
+++ b/pkg/client/aggregator/task.go
@@ -143,8 +143,8 @@ func (c *AggregatorClient) SendTaskToValidatorsBLS(ctx context.Context, taskResu
 	}
 
 	// Extract x,y coordinates from G1Point (like JavaScript g1ToHex)
-	xBig := signature.G1Point.X.BigInt(new(big.Int))
-	yBig := signature.G1Point.Y.BigInt(new(big.Int))
+	xBig := signature.X.BigInt(new(big.Int))
+	yBig := signature.Y.BigInt(new(big.Int))
 
 	// Convert to hex with proper formatting (32 bytes each for BN254)
 	xBytes := make([]byte, 32)

--- a/pkg/client/dbserver/time.go
+++ b/pkg/client/dbserver/time.go
@@ -27,7 +27,7 @@ func (c *DBServerClient) GetTimeBasedTasks() ([]types.ScheduleTimeTaskData, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var tasks []types.ScheduleTimeTaskData
 	err = json.Unmarshal(body, &tasks)

--- a/pkg/types/database.go
+++ b/pkg/types/database.go
@@ -42,6 +42,7 @@ type JobData struct {
 	UpdatedAt      time.Time `json:"updated_at"`
 	LastExecutedAt time.Time `json:"last_executed_at"`
 	Timezone       string    `json:"timezone"`
+	IsImua         bool      `json:"is_imua"`
 }
 
 type TimeJobData struct {
@@ -138,6 +139,7 @@ type TaskData struct {
 	TaSignature          []byte    `json:"ta_signature"`
 	TaskSubmissionTxHash string    `json:"task_submission_tx_hash"`
 	IsSuccessful         bool      `json:"is_successful"`
+	IsImua               bool      `json:"is_imua"`
 }
 
 type KeeperData struct {

--- a/pkg/types/database.go
+++ b/pkg/types/database.go
@@ -164,6 +164,7 @@ type KeeperData struct {
 	ChatID            int64     `json:"chat_id"`
 	EmailID           string    `json:"email_id"`
 	LastCheckedIn     time.Time `json:"last_checked_in"`
+	OnImua            bool      `json:"on_imua"`
 }
 
 type ApiKey struct {

--- a/pkg/types/dbserver_create.go
+++ b/pkg/types/dbserver_create.go
@@ -50,6 +50,7 @@ type CreateJobRequest struct {
 	ArgType                   int      `json:"arg_type" validate:"required"`
 	Arguments                 []string `json:"arguments" validate:"required"`
 	DynamicArgumentsScriptUrl string   `json:"dynamic_arguments_script_url,omitempty" validate:"omitempty,url"`
+	IsImua                    bool     `json:"is_imua"`
 }
 
 type CreateJobResponse struct {

--- a/pkg/types/dbserver_create.go
+++ b/pkg/types/dbserver_create.go
@@ -90,6 +90,7 @@ type GoogleFormCreateKeeperData struct {
 	RewardsAddress string `json:"rewards_address" validate:"required,ethereum_address"`
 	KeeperName     string `json:"keeper_name" validate:"required,min=3,max=50"`
 	EmailID        string `json:"email_id" validate:"required,email"`
+	OnImua         bool   `json:"on_imua"`
 }
 
 // Create New API Key (SDK)

--- a/pkg/types/schedulers.go
+++ b/pkg/types/schedulers.go
@@ -5,60 +5,62 @@ import "time"
 // Target Data for all task types
 // DEVNOTE: I separated this from all schedule data types to accomodate multiple target calls on same trigger in future
 type TaskTargetData struct {
-	JobID                     int64     `json:"job_id"`
-	TaskID                    int64     `json:"task_id"`
-	TaskDefinitionID          int       `json:"task_definition_id"`
-	TargetChainID             string    `json:"target_chain_id"`
-	TargetContractAddress     string    `json:"target_contract_address"`
-	TargetFunction            string    `json:"target_function"`
-	ABI                       string    `json:"abi"`
-	ArgType                   int       `json:"arg_type"`
-	Arguments                 []string  `json:"arguments"`
-	DynamicArgumentsScriptUrl string    `json:"dynamic_arguments_script_url"`
+	JobID                     int64    `json:"job_id"`
+	TaskID                    int64    `json:"task_id"`
+	TaskDefinitionID          int      `json:"task_definition_id"`
+	TargetChainID             string   `json:"target_chain_id"`
+	TargetContractAddress     string   `json:"target_contract_address"`
+	TargetFunction            string   `json:"target_function"`
+	ABI                       string   `json:"abi"`
+	ArgType                   int      `json:"arg_type"`
+	Arguments                 []string `json:"arguments"`
+	DynamicArgumentsScriptUrl string   `json:"dynamic_arguments_script_url"`
 }
 
 // Monitoring Data for even and condition workers
 type EventWorkerData struct {
-	JobID                     int64     `json:"job_id"`
-	ExpirationTime            time.Time `json:"expiration_time"`
-	Recurring                 bool      `json:"recurring"`
-	TriggerChainID            string    `json:"trigger_chain_id"`
-	TriggerContractAddress    string    `json:"trigger_contract_address"`
-	TriggerEvent              string    `json:"trigger_event"`
+	JobID                  int64     `json:"job_id"`
+	ExpirationTime         time.Time `json:"expiration_time"`
+	Recurring              bool      `json:"recurring"`
+	TriggerChainID         string    `json:"trigger_chain_id"`
+	TriggerContractAddress string    `json:"trigger_contract_address"`
+	TriggerEvent           string    `json:"trigger_event"`
 }
 type ConditionWorkerData struct {
-	JobID                     int64     `json:"job_id"`
-	ExpirationTime            time.Time `json:"expiration_time"`
-	Recurring                 bool      `json:"recurring"`
-	ConditionType             string    `json:"condition_type"`
-	UpperLimit                float64   `json:"upper_limit"`
-	LowerLimit                float64   `json:"lower_limit"`
-	ValueSourceType           string    `json:"value_source_type"`
-	ValueSourceUrl            string    `json:"value_source_url"`
+	JobID           int64     `json:"job_id"`
+	ExpirationTime  time.Time `json:"expiration_time"`
+	Recurring       bool      `json:"recurring"`
+	ConditionType   string    `json:"condition_type"`
+	UpperLimit      float64   `json:"upper_limit"`
+	LowerLimit      float64   `json:"lower_limit"`
+	ValueSourceType string    `json:"value_source_type"`
+	ValueSourceUrl  string    `json:"value_source_url"`
 }
 
 // Data to pass to time scheduler
 type ScheduleTimeTaskData struct {
-	TaskID                    int64     `json:"task_id"`
-	TaskDefinitionID          int       `json:"task_definition_id"`
-	LastExecutedAt            time.Time `json:"last_executed_at"`
-	ExpirationTime            time.Time `json:"expiration_time"`
-	NextExecutionTimestamp    time.Time `json:"next_execution_timestamp"`
-	ScheduleType              string    `json:"schedule_type"`
-	TimeInterval              int64     `json:"time_interval"`
-	CronExpression            string    `json:"cron_expression"`
-	SpecificSchedule          string    `json:"specific_schedule"`
-	TaskTargetData            TaskTargetData `json:"task_target_data"`
+	TaskID                 int64          `json:"task_id"`
+	TaskDefinitionID       int            `json:"task_definition_id"`
+	LastExecutedAt         time.Time      `json:"last_executed_at"`
+	ExpirationTime         time.Time      `json:"expiration_time"`
+	NextExecutionTimestamp time.Time      `json:"next_execution_timestamp"`
+	ScheduleType           string         `json:"schedule_type"`
+	TimeInterval           int64          `json:"time_interval"`
+	CronExpression         string         `json:"cron_expression"`
+	SpecificSchedule       string         `json:"specific_schedule"`
+	TaskTargetData         TaskTargetData `json:"task_target_data"`
+	IsImua                 bool           `json:"is_imua"`
 }
 
 // Data to pass to condition scheduler
 type ScheduleConditionJobData struct {
-	JobID                     int64     `json:"job_id"`
-	TaskDefinitionID          int       `json:"task_definition_id"`
-	LastExecutedAt            time.Time `json:"last_executed_at"`
-	TaskTargetData            TaskTargetData `json:"task_target_data"`
-	EventWorkerData           EventWorkerData `json:"event_worker_data"`
-	ConditionWorkerData       ConditionWorkerData `json:"condition_worker_data"`
+	JobID               int64               `json:"job_id"`
+	TaskDefinitionID    int                 `json:"task_definition_id"`
+	LastExecutedAt      time.Time           `json:"last_executed_at"`
+	TaskTargetData      TaskTargetData      `json:"task_target_data"`
+	EventWorkerData     EventWorkerData     `json:"event_worker_data"`
+	ConditionWorkerData ConditionWorkerData `json:"condition_worker_data"`
+	IsImua              bool                `json:"is_imua"`
 }
 
 // Trigger data from schedulers to keepers for validation
@@ -69,12 +71,12 @@ type TaskTriggerData struct {
 	ExpirationTime   time.Time `json:"expiration_time"`
 	// For event and Condition, it would be when the trigger happened, for time it would when the Job.LastExecutedAt
 	CurrentTriggerTimestamp time.Time `json:"trigger_timestamp"`
-	
+
 	NextTriggerTimestamp time.Time `json:"next_trigger_timestamp"`
-	TimeScheduleType     string `json:"time_schedule_type"`
-	TimeCronExpression   string `json:"time_cron_expression"`
-	TimeSpecificSchedule string `json:"time_specific_schedule"`
-	TimeInterval         int64  `json:"time_interval"`
+	TimeScheduleType     string    `json:"time_schedule_type"`
+	TimeCronExpression   string    `json:"time_cron_expression"`
+	TimeSpecificSchedule string    `json:"time_specific_schedule"`
+	TimeInterval         int64     `json:"time_interval"`
 
 	EventChainId                string `json:"event_chain_id"`
 	EventTxHash                 string `json:"event_tx_hash"`
@@ -98,9 +100,9 @@ type SchedulerSignatureData struct {
 
 type SendTaskDataToKeeper struct {
 	TaskID             int64                   `json:"task_id"`
-	PerformerData      PerformerData        `json:"performer_data"`
-	TargetData         []TaskTargetData         `json:"target_data"`
-	TriggerData        []TaskTriggerData        `json:"trigger_data"`
+	PerformerData      PerformerData           `json:"performer_data"`
+	TargetData         []TaskTargetData        `json:"target_data"`
+	TriggerData        []TaskTriggerData       `json:"trigger_data"`
 	SchedulerSignature *SchedulerSignatureData `json:"scheduler_signature_data"`
 }
 

--- a/scripts/create-job.sh
+++ b/scripts/create-job.sh
@@ -68,8 +68,8 @@ case $TASK_DEFINITION_ID in
     ;;
 esac
 
-# curl -X POST https://data.triggerx.network/api/jobs \
-curl -X POST http://192.168.1.56:9002/api/jobs \
+# curl -X POST https://data.triggerx.network/api/jobs \ 192.168.1.56
+curl -X POST http://localhost:9002/api/jobs \
   -H "Content-Type: application/json" \
   -d "[
     {
@@ -100,6 +100,7 @@ curl -X POST http://192.168.1.56:9002/api/jobs \
       \"target_function\": \"incrementBy\",
       \"abi\": \"[{\\\"anonymous\\\":false,\\\"inputs\\\":[{\\\"indexed\\\":false,\\\"internalType\\\":\\\"uint256\\\",\\\"name\\\":\\\"previousValue\\\",\\\"type\\\":\\\"uint256\\\"},{\\\"indexed\\\":false,\\\"internalType\\\":\\\"uint256\\\",\\\"name\\\":\\\"newValue\\\",\\\"type\\\":\\\"uint256\\\"},{\\\"indexed\\\":false,\\\"internalType\\\":\\\"uint256\\\",\\\"name\\\":\\\"incrementAmount\\\",\\\"type\\\":\\\"uint256\\\"}],\\\"name\\\":\\\"CounterIncremented\\\",\\\"type\\\":\\\"event\\\"},{\\\"inputs\\\":[],\\\"name\\\":\\\"getCount\\\",\\\"outputs\\\":[{\\\"internalType\\\":\\\"uint256\\\",\\\"name\\\":\\\"\\\",\\\"type\\\":\\\"uint256\\\"}],\\\"stateMutability\\\":\\\"view\\\",\\\"type\\\":\\\"function\\\"},{\\\"inputs\\\":[],\\\"name\\\":\\\"increment\\\",\\\"outputs\\\":[],\\\"stateMutability\\\":\\\"nonpayable\\\",\\\"type\\\":\\\"function\\\"},{\\\"inputs\\\":[{\\\"internalType\\\":\\\"uint256\\\",\\\"name\\\":\\\"amount\\\",\\\"type\\\":\\\"uint256\\\"}],\\\"name\\\":\\\"incrementBy\\\",\\\"outputs\\\":[],\\\"stateMutability\\\":\\\"nonpayable\\\",\\\"type\\\":\\\"function\\\"}]\",
       \"arg_type\": $ARG_TYPE,
+      \"is_imua\": true,
       \"arguments\": [\"3\"],
       \"dynamic_arguments_script_url\": \"$DYNAMIC_ARGUMENTS_SCRIPT_URL\"
     }

--- a/scripts/database/init-db.cql
+++ b/scripts/database/init-db.cql
@@ -180,6 +180,7 @@ CREATE TABLE IF NOT EXISTS keeper_data (
     chat_id bigint,
     email_id text,
     last_checked_in timestamp,
+    on_imua boolean,
     PRIMARY KEY (keeper_id)
 );
 

--- a/scripts/database/init-db.cql
+++ b/scripts/database/init-db.cql
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS job_data (
     updated_at timestamp,
     last_executed_at timestamp,
     timezone text,
+    is_imua boolean,
     PRIMARY KEY (job_id)
 );
 
@@ -151,6 +152,7 @@ CREATE TABLE IF NOT EXISTS task_data (
     ta_signature blob,
     task_submission_tx_hash text,
     is_successful boolean,
+    is_imua boolean,
     PRIMARY KEY (task_id)
 );
 


### PR DESCRIPTION
# Pull Request

## Description
This PR refactors the CreateKeeperDataGoogleForm handler to use the repository and query pattern, aligning it with the existing CreateKeeperData handler. This improves maintainability, testability, and consistency across the codebase.

##Key Changes

- Handler Refactor:

CreateKeeperDataGoogleForm no longer accesses the database directly.
Now uses repository methods for all DB operations.
Returns a consistent response with the keeper_id and status (created or existing).

- Repository Layer:

Added CheckKeeperExistsByAddress and CreateOrUpdateKeeperFromGoogleForm methods to the KeeperRepository interface and implementation.
These methods encapsulate all logic for checking existence and creating/updating keepers from Google Form data.

- Queries:

Added new queries in internal/dbserver/repository/queries/keeper_queries.go to support all fields from the Google Form, including rewards_address and on_imua.

- Testing:

Updated MockKeeperRepository in tests to implement the new interface methods, ensuring all tests compile and run.
No breaking changes to existing tests; interface is now fully satisfied.
#174 