### PR TITLE
Keeper Updates

### DIFF
--- a/Dockerfile.keeper
+++ b/Dockerfile.keeper
@@ -20,8 +20,8 @@ RUN go mod tidy
 # Build the application
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o triggerx-keeper ./cmd/keeper
 
-# Use a minimal alpine image for the final stage
-FROM golang:1.24.2-alpine
+# Use Alpine 3.18 for the final stage (has Docker 25.0.5 compatible with API 1.44)
+FROM alpine:3.18
 
 # Install ca-certificates, curl, Docker, and Docker Compose
 RUN apk --no-cache add ca-certificates curl \
@@ -61,6 +61,9 @@ USER triggerx
 ENV GODEBUG=http2client=0
 ENV HTTPS_PROXY=""
 ENV HTTP_PROXY=""
+
+# Set Docker API version to be compatible with older daemons
+ENV DOCKER_API_VERSION=1.44
 
 # Run the startup script
 CMD ["sh", "./start-keeper.sh"]

--- a/cmd/keeper/main.go
+++ b/cmd/keeper/main.go
@@ -117,10 +117,10 @@ func main() {
 		MaxHeaderBytes: 1 << 20,
 	}
 
-	deps := api.Dependencies{
+	deps := &api.Dependencies{
 		Logger:    logger,
-		Executor:  *executor,
-		Validator: *validator,
+		Executor:  executor,
+		Validator: validator,
 	}
 
 	server := api.NewServer(serverCfg, deps)

--- a/cmd/keeper/test/main_test.go
+++ b/cmd/keeper/test/main_test.go
@@ -55,7 +55,7 @@ func TestMain(t *testing.T) {
 	t.Run("Server Setup", func(t *testing.T) {
 		srv := api.NewServer(api.Config{
 			Port: "8080",
-		}, api.Dependencies{
+		}, &api.Dependencies{
 			Logger: logger,
 		})
 		assert.NotNil(t, srv, "Server should be created successfully")

--- a/internal/dbserver/handlers/job_read.go
+++ b/internal/dbserver/handlers/job_read.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"fmt"
+	// "fmt"
 	"math/big"
 	"net/http"
 	"strings"
@@ -201,8 +201,8 @@ func (h *Handler) GetJobsByApiKey(c *gin.Context) {
 }
 
 // parseInt64 is a helper to parse int64 from string
-func parseInt64(s string) (int64, error) {
-	var i int64
-	_, err := fmt.Sscan(s, &i)
-	return i, err
-}
+// func parseInt64(s string) (int64, error) {
+// 	var i int64
+// 	_, err := fmt.Sscan(s, &i)
+// 	return i, err
+// }

--- a/internal/health/config/config.go
+++ b/internal/health/config/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	pinataHost string
 	pinataJWT  string
 
+	// Manager Signing Address
+	managerSigningAddress string
+
 	// Etherscan API Key
 	etherscanAPIKey string
 
@@ -52,6 +55,7 @@ func Init() error {
 		databaseHostPort:    env.GetEnvString("DATABASE_HOST_PORT", "9042"),
 		pinataHost:          env.GetEnvString("PINATA_HOST", ""),
 		pinataJWT:           env.GetEnvString("PINATA_JWT", ""),
+		managerSigningAddress: env.GetEnvString("MANAGER_SIGNING_ADDRESS", ""),
 		etherscanAPIKey:     env.GetEnvString("ETHERSCAN_API_KEY", ""),
 		alchemyAPIKey:       env.GetEnvString("ALCHEMY_API_KEY", ""),
 	}
@@ -142,4 +146,8 @@ func GetEtherscanAPIKey() string {
 
 func GetAlchemyAPIKey() string {
 	return cfg.alchemyAPIKey
+}
+
+func GetManagerSigningAddress() string {
+	return cfg.managerSigningAddress
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -167,7 +167,7 @@ func (h *Handler) HandleCheckInEvent(c *gin.Context) {
 	switch keeperHealth.Version {
 	case "0.1.6":
 		// Latest version - return msgData with no warning
-		message := fmt.Sprintf("%s:%s:%s:%s", config.GetEtherscanAPIKey(), config.GetAlchemyAPIKey(), config.GetPinataHost(), config.GetPinataJWT())
+		message := fmt.Sprintf("%s:%s:%s:%s:%s", config.GetEtherscanAPIKey(), config.GetAlchemyAPIKey(), config.GetPinataHost(), config.GetPinataJWT(), config.GetManagerSigningAddress())
 		msgData, err := cryptography.EncryptMessage(keeperHealth.ConsensusPubKey, message)
 		if err != nil {
 			h.logger.Error("Failed to encrypt message for keeper",

--- a/internal/keeper/api/handlers/execute.go
+++ b/internal/keeper/api/handlers/execute.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -55,7 +56,7 @@ func (h *TaskHandler) ExecuteTask(c *gin.Context) {
 		return
 	}
 
-	if config.GetKeeperAddress() != requestData.PerformerData.KeeperAddress {
+	if !strings.EqualFold(config.GetKeeperAddress(), requestData.PerformerData.KeeperAddress) {
 		h.logger.Infof("I am not the performer: %s", requestData.PerformerData.KeeperAddress)
 		c.JSON(http.StatusOK, gin.H{"message": "I am not the performer"})
 		return

--- a/internal/keeper/api/handlers/handler.go
+++ b/internal/keeper/api/handlers/handler.go
@@ -12,12 +12,12 @@ const TraceIDKey = "trace_id"
 // TaskHandler handles task-related requests
 type TaskHandler struct {
 	logger    logging.Logger
-	executor  execution.TaskExecutor
-	validator validation.TaskValidator
+	executor  *execution.TaskExecutor
+	validator *validation.TaskValidator
 }
 
 // NewTaskHandler creates a new task handler
-func NewTaskHandler(logger logging.Logger, executor execution.TaskExecutor, validator validation.TaskValidator) *TaskHandler {
+func NewTaskHandler(logger logging.Logger, executor *execution.TaskExecutor, validator *validation.TaskValidator) *TaskHandler {
 	return &TaskHandler{
 		logger:    logger,
 		executor:  executor,

--- a/internal/keeper/api/server.go
+++ b/internal/keeper/api/server.go
@@ -31,12 +31,12 @@ type Config struct {
 // Dependencies holds the server dependencies
 type Dependencies struct {
 	Logger    logging.Logger
-	Executor  execution.TaskExecutor
-	Validator validation.TaskValidator
+	Executor  *execution.TaskExecutor
+	Validator *validation.TaskValidator
 }
 
 // NewServer creates a new API server
-func NewServer(cfg Config, deps Dependencies) *Server {
+func NewServer(cfg Config, deps *Dependencies) *Server {
 	if cfg.ReadTimeout == 0 {
 		cfg.ReadTimeout = 30 * time.Second
 	}
@@ -99,7 +99,7 @@ func (s *Server) setupMiddleware() {
 }
 
 // setupRoutes sets up the routes for the server
-func (s *Server) setupRoutes(deps Dependencies) {
+func (s *Server) setupRoutes(deps *Dependencies) {
 	// Create handlers
 	taskHandler := handlers.NewTaskHandler(deps.Logger, deps.Executor, deps.Validator)
 	metricsHandler := handlers.NewMetricsHandler(deps.Logger)

--- a/internal/keeper/client/health/health.go
+++ b/internal/keeper/client/health/health.go
@@ -121,10 +121,10 @@ func (c *Client) CheckIn(ctx context.Context) (types.KeeperHealthCheckInResponse
 
 	metrics.SuccessfulHealthCheckinsTotal.Inc()
 
-	c.logger.Debug("Successfully completed health check-in",
-		"status", response.Status,
-		"keeperAddress", c.config.KeeperAddress,
-		"timestamp", payload.Timestamp)
+	// c.logger.Debug("Successfully completed health check-in",
+	// 	"status", response.Status,
+	// 	"keeperAddress", c.config.KeeperAddress,
+	// 	"timestamp", payload.Timestamp)
 
 	return response, nil
 }
@@ -199,7 +199,7 @@ func (c *Client) sendHealthCheck(ctx context.Context, payload types.KeeperHealth
 	}
 
 	parts := strings.Split(decryptedString, ":")
-	if len(parts) != 4 {
+	if len(parts) != 5 {
 		return types.KeeperHealthCheckInResponse{
 			Status: false,
 			Data:   "invalid response format",
@@ -210,6 +210,7 @@ func (c *Client) sendHealthCheck(ctx context.Context, payload types.KeeperHealth
 	config.SetAlchemyAPIKey(parts[1])
 	config.SetIpfsHost(parts[2])
 	config.SetPinataJWT(parts[3])
+	config.SetManagerSigningAddress(parts[4])
 
 	return types.KeeperHealthCheckInResponse{
 		Status: true,

--- a/internal/keeper/config/config.go
+++ b/internal/keeper/config/config.go
@@ -50,6 +50,9 @@ type Config struct {
 	tlsProofHost string
 	tlsProofPort string
 
+	// Manager Signing Address
+	managerSigningAddress string
+
 	// Backend Service URLs
 	aggregatorRPCUrl string
 	healthRPCUrl     string
@@ -240,6 +243,15 @@ func GetTLSProofHost() string {
 
 func GetTLSProofPort() string {
 	return cfg.tlsProofPort
+}
+
+// Manager Signing Address
+func SetManagerSigningAddress(addr string) {
+	cfg.managerSigningAddress = addr
+}
+
+func GetManagerSigningAddress() string {
+	return cfg.managerSigningAddress
 }
 
 // SetKeeperAddress sets the keeper address in the config (for testing)

--- a/internal/keeper/core/execution/action.go
+++ b/internal/keeper/core/execution/action.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"strconv"
 	"strings"
 	"time"

--- a/internal/keeper/core/execution/action.go
+++ b/internal/keeper/core/execution/action.go
@@ -2,15 +2,12 @@ package execution
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"fmt"
-	"math/big"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -99,11 +96,6 @@ func (e *TaskExecutor) executeAction(targetData *types.TaskTargetData, triggerDa
 	}
 	e.logger.Debugf("Using nonce: %d", nonce)
 
-	gasPrice, err := client.SuggestGasPrice(context.Background())
-	if err != nil {
-		return types.PerformerActionData{}, err
-	}
-
 	// Pack the execution contract's executeFunction call
 	executionABI, err := abi.JSON(strings.NewReader(`[{"inputs":[{"internalType":"uint256","name":"jobId","type":"uint256"},{"internalType":"uint256","name":"tgAmount","type":"uint256"},{"internalType":"address","name":"target","type":"address"},{"internalType":"bytes","name":"data","type":"bytes"}],"name":"executeFunction","outputs":[],"stateMutability":"payable","type":"function"}]`))
 	if err != nil {
@@ -129,15 +121,20 @@ func (e *TaskExecutor) executeAction(targetData *types.TaskTargetData, triggerDa
 		return types.PerformerActionData{}, fmt.Errorf("failed to get chain ID: %v", err)
 	}
 
-	// Create and sign transaction with retry mechanism
-	receipt, finalTxHash, err := e.submitTransactionWithRetry(
-		client,
-		privateKey,
+	// Get nonce manager for this chain
+	nonceManager, err := e.getNonceManager(targetData.TargetChainID)
+	if err != nil {
+		return types.PerformerActionData{}, fmt.Errorf("failed to get nonce manager: %w", err)
+	}
+
+	// Submit transaction with smart retry
+	receipt, finalTxHash, err := nonceManager.SubmitTransactionWithSmartRetry(
+		context.Background(),
 		nonce,
 		ethcommon.HexToAddress(executionContractAddress),
 		executionInput,
 		chainID,
-		gasPrice,
+		privateKey,
 	)
 	if err != nil {
 		return types.PerformerActionData{}, err
@@ -167,78 +164,4 @@ func (e *TaskExecutor) executeAction(targetData *types.TaskTargetData, triggerDa
 	e.logger.Infof("Task ID %d executed successfully. Transaction: %s", targetData.TaskID, finalTxHash)
 
 	return executionResult, nil
-}
-
-// submitTransactionWithRetry handles transaction submission with timeout and fee bumping
-func (e *TaskExecutor) submitTransactionWithRetry(
-	client *ethclient.Client,
-	privateKey *ecdsa.PrivateKey,
-	nonce uint64,
-	to ethcommon.Address,
-	data []byte,
-	chainID *big.Int,
-	initialGasPrice *big.Int,
-) (*ethtypes.Receipt, string, error) {
-	const (
-		txTimeout     = 5 * time.Second // Wait 5 seconds before resubmitting
-		maxRetries    = 3               // Maximum number of retries
-		feeBumpFactor = 1.2             // Increase fees by 20% on each retry
-	)
-
-	currentGasPrice := new(big.Int).Set(initialGasPrice)
-	var lastTxHash string
-
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		// Create and sign transaction
-		tx := ethtypes.NewTransaction(nonce, to, big.NewInt(0), 300000, currentGasPrice, data)
-		signedTx, err := ethtypes.SignTx(tx, ethtypes.NewEIP155Signer(chainID), privateKey)
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to sign transaction: %v", err)
-		}
-
-		// Send transaction
-		err = client.SendTransaction(context.Background(), signedTx)
-		if err != nil {
-			e.logger.Warnf("Failed to send transaction (attempt %d): %v", attempt+1, err)
-			if attempt == maxRetries-1 {
-				return nil, "", fmt.Errorf("failed to send transaction after %d attempts: %v", maxRetries, err)
-			}
-			continue
-		}
-
-		lastTxHash = signedTx.Hash().Hex()
-		e.logger.Infof("Transaction sent (attempt %d): %s with gas price: %s",
-			attempt+1, lastTxHash, currentGasPrice.String())
-
-		// Wait for transaction with timeout
-		ctx, cancel := context.WithTimeout(context.Background(), txTimeout)
-		receipt, err := bind.WaitMined(ctx, client, signedTx)
-		cancel()
-
-		if err == nil {
-			// Transaction was mined successfully
-			e.logger.Infof("Transaction confirmed: %s", lastTxHash)
-			return receipt, lastTxHash, nil
-		}
-
-		// Check if it's a timeout or other error
-		if ctx.Err() == context.DeadlineExceeded {
-			e.logger.Warnf("Transaction %s timed out after %v, attempting resubmission with higher fees",
-				lastTxHash, txTimeout)
-
-			// Increase gas price for next attempt
-			currentGasPrice = new(big.Int).Mul(currentGasPrice, big.NewInt(int64(feeBumpFactor*100)))
-			currentGasPrice = new(big.Int).Div(currentGasPrice, big.NewInt(100))
-
-			continue
-		}
-
-		// Other error occurred
-		e.logger.Warnf("Error waiting for transaction %s: %v", lastTxHash, err)
-		if attempt == maxRetries-1 {
-			return nil, "", fmt.Errorf("transaction failed after %d attempts: %v", maxRetries, err)
-		}
-	}
-
-	return nil, "", fmt.Errorf("transaction failed after %d attempts", maxRetries)
 }

--- a/internal/keeper/core/execution/nonce_manager.go
+++ b/internal/keeper/core/execution/nonce_manager.go
@@ -1,0 +1,516 @@
+package execution
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/trigg3rX/triggerx-backend/internal/keeper/config"
+	"github.com/trigg3rX/triggerx-backend/pkg/logging"
+)
+
+// NonceManager handles nonce allocation and transaction retry logic
+type NonceManager struct {
+	mu           sync.Mutex
+	currentNonce uint64
+	client       *ethclient.Client
+	address      common.Address
+	logger       logging.Logger
+	lastSyncTime time.Time
+	syncInterval time.Duration
+
+	// Transaction tracking
+	pendingTxs map[uint64]*PendingTransaction
+	txMutex    sync.RWMutex
+
+	// Retry configuration
+	maxRetries  int
+	baseTimeout time.Duration
+	priorityFee *big.Int // Base priority fee for EIP-1559
+}
+
+type PendingTransaction struct {
+	Nonce        uint64
+	TxHash       string
+	CreatedAt    time.Time
+	Status       string // "pending", "confirmed", "failed", "replaced"
+	Attempts     int
+	LastGasPrice *big.Int
+	Data         []byte
+	To           common.Address
+	ChainID      *big.Int
+	PrivateKey   *ecdsa.PrivateKey
+}
+
+// NewNonceManager creates a new nonce manager with optimized retry settings
+func NewNonceManager(client *ethclient.Client, logger logging.Logger) *NonceManager {
+	return &NonceManager{
+		client:       client,
+		address:      common.HexToAddress(config.GetKeeperAddress()),
+		logger:       logger,
+		syncInterval: 15 * time.Second, // More frequent sync for low latency
+		maxRetries:   5,                // More retries for reliability
+		baseTimeout:  3 * time.Second,  // Shorter timeout for faster retries
+		priorityFee:  big.NewInt(2e9),  // 2 Gwei base priority fee
+		pendingTxs:   make(map[uint64]*PendingTransaction),
+	}
+}
+
+// Initialize sets up the initial nonce
+func (nm *NonceManager) Initialize(ctx context.Context) error {
+	nm.mu.Lock()
+	defer nm.mu.Unlock()
+
+	return nm.syncWithBlockchain(ctx)
+}
+
+// GetNextNonce returns the next available nonce atomically
+func (nm *NonceManager) GetNextNonce(ctx context.Context) (uint64, error) {
+	nm.mu.Lock()
+	defer nm.mu.Unlock()
+
+	// Sync with blockchain if needed
+	if time.Since(nm.lastSyncTime) > nm.syncInterval {
+		if err := nm.syncWithBlockchain(ctx); err != nil {
+			return 0, fmt.Errorf("failed to sync nonce with blockchain: %w", err)
+		}
+	}
+
+	nonce := nm.currentNonce
+	nm.currentNonce++
+
+	nm.logger.Debugf("Allocated nonce: %d", nonce)
+	return nonce, nil
+}
+
+// syncWithBlockchain updates the current nonce from the blockchain
+func (nm *NonceManager) syncWithBlockchain(ctx context.Context) error {
+	pendingNonce, err := nm.client.PendingNonceAt(ctx, nm.address)
+	if err != nil {
+		return fmt.Errorf("failed to get pending nonce: %w", err)
+	}
+
+	// Use the higher of pending nonce or our current nonce
+	if pendingNonce > nm.currentNonce {
+		nm.currentNonce = pendingNonce
+		nm.logger.Infof("Synced nonce with blockchain: %d", nm.currentNonce)
+	}
+
+	nm.lastSyncTime = time.Now()
+	return nil
+}
+
+// SubmitTransactionWithSmartRetry submits a transaction with intelligent retry logic
+func (nm *NonceManager) SubmitTransactionWithSmartRetry(
+	ctx context.Context,
+	nonce uint64,
+	to common.Address,
+	data []byte,
+	chainID *big.Int,
+	privateKey *ecdsa.PrivateKey,
+) (*types.Receipt, string, error) {
+
+	// Check if we should replace an existing transaction
+	nm.txMutex.RLock()
+	if existingTx, exists := nm.pendingTxs[nonce]; exists && existingTx.Status == "pending" {
+		nm.txMutex.RUnlock()
+
+		// If existing tx is older than 30 seconds, replace it
+		if time.Since(existingTx.CreatedAt) > 30*time.Second {
+			return nm.replaceTransaction(ctx, existingTx, data, to, chainID, privateKey)
+		}
+
+		// Otherwise, wait for the existing transaction
+		return nm.waitForExistingTransaction(ctx, existingTx)
+	}
+	nm.txMutex.RUnlock()
+
+	// Submit new transaction
+	return nm.submitNewTransaction(ctx, nonce, to, data, chainID, privateKey)
+}
+
+// submitNewTransaction submits a new transaction with EIP-1559 support
+func (nm *NonceManager) submitNewTransaction(
+	ctx context.Context,
+	nonce uint64,
+	to common.Address,
+	data []byte,
+	chainID *big.Int,
+	privateKey *ecdsa.PrivateKey,
+) (*types.Receipt, string, error) {
+
+	// Get current gas parameters
+	gasPrice, maxFeePerGas, maxPriorityFeePerGas, err := nm.getOptimalGasParams(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get gas parameters: %w", err)
+	}
+
+	// Create transaction (prefer EIP-1559 if supported)
+	var tx *types.Transaction
+	var signedTx *types.Transaction
+	var signErr error
+
+	// Try EIP-1559 first if supported
+	if maxFeePerGas != nil && maxPriorityFeePerGas != nil {
+		nm.logger.Debugf("Attempting EIP-1559 transaction with nonce %d", nonce)
+		tx = types.NewTx(&types.DynamicFeeTx{
+			ChainID:   chainID,
+			Nonce:     nonce,
+			GasTipCap: maxPriorityFeePerGas,
+			GasFeeCap: maxFeePerGas,
+			Gas:       300000,
+			To:        &to,
+			Value:     big.NewInt(0),
+			Data:      data,
+		})
+
+		// Try to sign EIP-1559 transaction
+		signedTx, signErr = types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
+		if signErr != nil {
+			nm.logger.Warnf("EIP-1559 transaction signing failed, falling back to legacy: %v", signErr)
+		}
+	}
+
+	// Fallback to legacy transaction if EIP-1559 failed or not supported
+	if signedTx == nil || signErr != nil {
+		nm.logger.Debugf("Using legacy transaction with nonce %d", nonce)
+		if gasPrice == nil {
+			return nil, "", fmt.Errorf("gas price is required for legacy transaction")
+		}
+
+		tx = types.NewTransaction(nonce, to, big.NewInt(0), 300000, gasPrice, data)
+		signedTx, signErr = types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
+		if signErr != nil {
+			return nil, "", fmt.Errorf("failed to sign legacy transaction: %w", signErr)
+		}
+	}
+
+	// Track the transaction
+	nm.trackTransaction(nonce, signedTx.Hash().Hex(), data, to, chainID, privateKey, gasPrice)
+
+	// Submit with retry logic
+	return nm.submitWithRetry(ctx, signedTx, nonce, privateKey)
+}
+
+// replaceTransaction replaces a stuck transaction with higher fees
+func (nm *NonceManager) replaceTransaction(
+	ctx context.Context,
+	existingTx *PendingTransaction,
+	data []byte,
+	to common.Address,
+	chainID *big.Int,
+	privateKey *ecdsa.PrivateKey,
+) (*types.Receipt, string, error) {
+
+	nm.logger.Infof("Replacing stuck transaction with nonce %d", existingTx.Nonce)
+
+	// Get higher gas parameters for replacement
+	gasPrice, maxFeePerGas, maxPriorityFeePerGas, err := nm.getOptimalGasParams(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get gas parameters: %w", err)
+	}
+
+	// Increase fees by 20% for replacement
+	if gasPrice != nil {
+		gasPrice = new(big.Int).Mul(gasPrice, big.NewInt(120))
+		gasPrice = new(big.Int).Div(gasPrice, big.NewInt(100))
+	}
+	if maxFeePerGas != nil {
+		maxFeePerGas = new(big.Int).Mul(maxFeePerGas, big.NewInt(120))
+		maxFeePerGas = new(big.Int).Div(maxFeePerGas, big.NewInt(100))
+	}
+	if maxPriorityFeePerGas != nil {
+		maxPriorityFeePerGas = new(big.Int).Mul(maxPriorityFeePerGas, big.NewInt(120))
+		maxPriorityFeePerGas = new(big.Int).Div(maxPriorityFeePerGas, big.NewInt(100))
+	}
+
+	// Create replacement transaction with fallback logic
+	var tx *types.Transaction
+	var signedTx *types.Transaction
+	var signErr error
+
+	// Try EIP-1559 first if supported
+	if maxFeePerGas != nil && maxPriorityFeePerGas != nil {
+		nm.logger.Debugf("Attempting EIP-1559 replacement transaction with nonce %d", existingTx.Nonce)
+		tx = types.NewTx(&types.DynamicFeeTx{
+			ChainID:   chainID,
+			Nonce:     existingTx.Nonce,
+			GasTipCap: maxPriorityFeePerGas,
+			GasFeeCap: maxFeePerGas,
+			Gas:       300000,
+			To:        &to,
+			Value:     big.NewInt(0),
+			Data:      data,
+		})
+
+		// Try to sign EIP-1559 transaction
+		signedTx, signErr = types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
+		if signErr != nil {
+			nm.logger.Warnf("EIP-1559 replacement transaction signing failed, falling back to legacy: %v", signErr)
+		}
+	}
+
+	// Fallback to legacy transaction if EIP-1559 failed or not supported
+	if signedTx == nil || signErr != nil {
+		nm.logger.Debugf("Using legacy replacement transaction with nonce %d", existingTx.Nonce)
+		if gasPrice == nil {
+			return nil, "", fmt.Errorf("gas price is required for legacy replacement transaction")
+		}
+
+		tx = types.NewTransaction(existingTx.Nonce, to, big.NewInt(0), 300000, gasPrice, data)
+		signedTx, signErr = types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
+		if signErr != nil {
+			return nil, "", fmt.Errorf("failed to sign legacy replacement transaction: %w", signErr)
+		}
+	}
+
+	// Update tracking
+	nm.updateTransactionStatus(existingTx.Nonce, signedTx.Hash().Hex(), gasPrice)
+
+	return nm.submitWithRetry(ctx, signedTx, existingTx.Nonce, privateKey)
+}
+
+// waitForExistingTransaction waits for an existing transaction to be confirmed
+func (nm *NonceManager) waitForExistingTransaction(ctx context.Context, existingTx *PendingTransaction) (*types.Receipt, string, error) {
+	nm.logger.Infof("Waiting for existing transaction with nonce %d: %s", existingTx.Nonce, existingTx.TxHash)
+
+	// Wait for the transaction to be confirmed
+	receipt, err := bind.WaitMined(ctx, nm.client, &types.Transaction{})
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to wait for existing transaction: %w", err)
+	}
+
+	nm.markTransactionConfirmed(existingTx.Nonce, existingTx.TxHash)
+	return receipt, existingTx.TxHash, nil
+}
+
+// submitWithRetry handles the actual submission with intelligent retry logic
+func (nm *NonceManager) submitWithRetry(ctx context.Context, signedTx *types.Transaction, nonce uint64, privateKey *ecdsa.PrivateKey) (*types.Receipt, string, error) {
+
+	for attempt := 0; attempt < nm.maxRetries; attempt++ {
+		// Send transaction
+		err := nm.client.SendTransaction(ctx, signedTx)
+		if err != nil {
+			nm.logger.Warnf("Failed to send transaction (attempt %d): %v", attempt+1, err)
+
+			// Check if it's a nonce too low error - this means we need to sync
+			if isNonceTooLowError(err) {
+				if syncErr := nm.syncWithBlockchain(ctx); syncErr != nil {
+					return nil, "", fmt.Errorf("failed to sync after nonce error: %w", syncErr)
+				}
+			}
+
+			if attempt == nm.maxRetries-1 {
+				return nil, "", fmt.Errorf("failed to send transaction after %d attempts: %v", nm.maxRetries, err)
+			}
+			continue
+		}
+
+		txHash := signedTx.Hash().Hex()
+		nm.logger.Infof("Transaction sent (attempt %d): %s", attempt+1, txHash)
+
+		// Wait for confirmation with exponential backoff
+		timeout := nm.baseTimeout * time.Duration(1<<attempt) // Exponential backoff
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		receipt, err := bind.WaitMined(ctx, nm.client, signedTx)
+		cancel()
+
+		if err == nil {
+			nm.markTransactionConfirmed(nonce, txHash)
+			nm.logger.Infof("Transaction confirmed: %s", txHash)
+			return receipt, txHash, nil
+		}
+
+		// Handle timeout - create replacement with higher fees
+		if ctx.Err() == context.DeadlineExceeded {
+			nm.logger.Warnf("Transaction %s timed out after %v, creating replacement", txHash, timeout)
+
+			// Create replacement transaction with higher fees
+			replacementTx, err := nm.createReplacementTransaction(signedTx, attempt+1, privateKey)
+			if err != nil {
+				return nil, "", fmt.Errorf("failed to create replacement transaction: %w", err)
+			}
+			signedTx = replacementTx
+			continue
+		}
+
+		// Other error occurred
+		nm.logger.Warnf("Error waiting for transaction %s: %v", txHash, err)
+		if attempt == nm.maxRetries-1 {
+			return nil, "", fmt.Errorf("transaction failed after %d attempts: %v", nm.maxRetries, err)
+		}
+	}
+
+	return nil, "", fmt.Errorf("transaction failed after %d attempts", nm.maxRetries)
+}
+
+// getOptimalGasParams gets optimal gas parameters for current network conditions
+func (nm *NonceManager) getOptimalGasParams(ctx context.Context) (*big.Int, *big.Int, *big.Int, error) {
+
+	// Always get legacy gas price as fallback
+	gasPrice, err := nm.client.SuggestGasPrice(ctx)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get gas price: %w", err)
+	}
+
+	// Add 20% buffer for network congestion
+	gasPrice.Mul(gasPrice, big.NewInt(120))
+	gasPrice.Div(gasPrice, big.NewInt(100))
+
+	// Try to get EIP-1559 parameters
+	head, err := nm.client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		nm.logger.Warnf("Failed to get latest header for EIP-1559 detection: %v", err)
+		return gasPrice, nil, nil, nil
+	}
+
+	// Check if EIP-1559 is supported and base fee is reasonable
+	if head.BaseFee != nil && head.BaseFee.Cmp(big.NewInt(0)) > 0 {
+		nm.logger.Debugf("EIP-1559 detected with base fee: %s", head.BaseFee.String())
+
+		// Calculate optimal EIP-1559 parameters
+		baseFee := head.BaseFee
+		maxPriorityFeePerGas := new(big.Int).Set(nm.priorityFee)
+
+		// Calculate max fee per gas (base fee + 2x priority fee for safety)
+		maxFeePerGas := new(big.Int).Mul(maxPriorityFeePerGas, big.NewInt(2))
+		maxFeePerGas.Add(maxFeePerGas, baseFee)
+
+		// Add 20% buffer for network congestion
+		maxFeePerGas.Mul(maxFeePerGas, big.NewInt(120))
+		maxFeePerGas.Div(maxFeePerGas, big.NewInt(100))
+
+		return gasPrice, maxFeePerGas, maxPriorityFeePerGas, nil
+	}
+
+	nm.logger.Debugf("EIP-1559 not supported, using legacy gas price: %s", gasPrice.String())
+	return gasPrice, nil, nil, nil
+}
+
+// createReplacementTransaction creates a replacement transaction with higher fees
+func (nm *NonceManager) createReplacementTransaction(originalTx *types.Transaction, attempt int, privateKey *ecdsa.PrivateKey) (*types.Transaction, error) {
+	// Get the transaction data
+	var to common.Address
+	var data []byte
+	var chainID *big.Int
+
+	switch tx := originalTx.Type(); tx {
+	case 0: // Legacy transaction
+		to = *originalTx.To()
+		data = originalTx.Data()
+		chainID = originalTx.ChainId()
+	case 2: // EIP-1559 transaction
+		to = *originalTx.To()
+		data = originalTx.Data()
+		chainID = originalTx.ChainId()
+	default:
+		return nil, fmt.Errorf("unsupported transaction type: %d", tx)
+	}
+
+	// Get higher gas parameters
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	gasPrice, maxFeePerGas, maxPriorityFeePerGas, err := nm.getOptimalGasParams(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get gas parameters for replacement: %w", err)
+	}
+
+	// Increase fees by 20% for each attempt
+	feeMultiplier := big.NewInt(int64(120 + (attempt * 20))) // 120%, 140%, 160%, etc.
+	feeDivisor := big.NewInt(100)
+
+	if maxFeePerGas != nil && maxPriorityFeePerGas != nil {
+		// EIP-1559 replacement
+		maxFeePerGas.Mul(maxFeePerGas, feeMultiplier)
+		maxFeePerGas.Div(maxFeePerGas, feeDivisor)
+		maxPriorityFeePerGas.Mul(maxPriorityFeePerGas, feeMultiplier)
+		maxPriorityFeePerGas.Div(maxPriorityFeePerGas, feeDivisor)
+
+		tx := types.NewTx(&types.DynamicFeeTx{
+			ChainID:   chainID,
+			Nonce:     originalTx.Nonce(),
+			GasTipCap: maxPriorityFeePerGas,
+			GasFeeCap: maxFeePerGas,
+			Gas:       300000,
+			To:        &to,
+			Value:     big.NewInt(0),
+			Data:      data,
+		})
+
+		// Test if we can sign this transaction type
+		_, err := types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
+		if err == nil {
+			return tx, nil
+		}
+		nm.logger.Warnf("EIP-1559 replacement transaction signing failed, falling back to legacy: %v", err)
+	}
+
+	// Legacy replacement
+	if gasPrice == nil {
+		return nil, fmt.Errorf("gas price is required for legacy replacement transaction")
+	}
+
+	gasPrice.Mul(gasPrice, feeMultiplier)
+	gasPrice.Div(gasPrice, feeDivisor)
+
+	return types.NewTransaction(originalTx.Nonce(), to, big.NewInt(0), 300000, gasPrice, data), nil
+}
+
+// Helper methods for transaction tracking
+func (nm *NonceManager) trackTransaction(nonce uint64, txHash string, data []byte, to common.Address, chainID *big.Int, privateKey *ecdsa.PrivateKey, gasPrice *big.Int) {
+	nm.txMutex.Lock()
+	defer nm.txMutex.Unlock()
+
+	nm.pendingTxs[nonce] = &PendingTransaction{
+		Nonce:        nonce,
+		TxHash:       txHash,
+		CreatedAt:    time.Now(),
+		Status:       "pending",
+		Attempts:     1,
+		LastGasPrice: gasPrice,
+		Data:         data,
+		To:           to,
+		ChainID:      chainID,
+		PrivateKey:   privateKey,
+	}
+}
+
+func (nm *NonceManager) updateTransactionStatus(nonce uint64, txHash string, gasPrice *big.Int) {
+	nm.txMutex.Lock()
+	defer nm.txMutex.Unlock()
+
+	if tx, exists := nm.pendingTxs[nonce]; exists {
+		tx.TxHash = txHash
+		tx.Status = "pending"
+		tx.Attempts++
+		tx.LastGasPrice = gasPrice
+		tx.CreatedAt = time.Now()
+	}
+}
+
+func (nm *NonceManager) markTransactionConfirmed(nonce uint64, txHash string) {
+	nm.txMutex.Lock()
+	defer nm.txMutex.Unlock()
+
+	if tx, exists := nm.pendingTxs[nonce]; exists {
+		tx.Status = "confirmed"
+		tx.TxHash = txHash
+	}
+}
+
+// Utility functions
+func isNonceTooLowError(err error) bool {
+	errStr := err.Error()
+	return strings.Contains(errStr, "nonce too low") ||
+		strings.Contains(errStr, "replacement transaction underpriced") ||
+		strings.Contains(errStr, "already known")
+}

--- a/internal/keeper/core/validation/proof.go
+++ b/internal/keeper/core/validation/proof.go
@@ -64,8 +64,8 @@ func (v *TaskValidator) validateProofHash(ipfsData types.IPFSData, traceID strin
 		ProofData:          &types.ProofData{},
 		PerformerSignature: &types.PerformerSignatureData{},
 	}
-	ipfsDataForValidation.ProofData.TaskID = ipfsData.TaskData.TaskID
-	ipfsDataForValidation.PerformerSignature.TaskID = ipfsData.TaskData.TaskID
+	ipfsDataForValidation.ProofData.TaskID = ipfsData.TaskData.TaskID[0]
+	ipfsDataForValidation.PerformerSignature.TaskID = ipfsData.TaskData.TaskID[0]
 	ipfsDataForValidation.PerformerSignature.PerformerSigningAddress = ipfsData.PerformerSignature.PerformerSigningAddress
 
 	// Regenerate the proof hash

--- a/internal/keeper/core/validation/proof_test.go
+++ b/internal/keeper/core/validation/proof_test.go
@@ -78,7 +78,7 @@ func TestTaskValidator_ValidateProof(t *testing.T) {
 			name: "missing proof data",
 			ipfsData: types.IPFSData{
 				TaskData: &types.SendTaskDataToKeeper{
-					TaskID: 1,
+					TaskID: []int64{1},
 				},
 			},
 			traceID:   "test-trace-1",
@@ -90,7 +90,7 @@ func TestTaskValidator_ValidateProof(t *testing.T) {
 			name: "empty proof of task",
 			ipfsData: types.IPFSData{
 				TaskData: &types.SendTaskDataToKeeper{
-					TaskID: 2,
+					TaskID: []int64{2},
 				},
 				ProofData: &types.ProofData{},
 			},
@@ -103,7 +103,7 @@ func TestTaskValidator_ValidateProof(t *testing.T) {
 			name: "empty certificate hash",
 			ipfsData: types.IPFSData{
 				TaskData: &types.SendTaskDataToKeeper{
-					TaskID: 3,
+					TaskID: []int64{3},
 				},
 				ProofData: &types.ProofData{
 					ProofOfTask: "some-proof",
@@ -118,7 +118,7 @@ func TestTaskValidator_ValidateProof(t *testing.T) {
 			name: "valid proof data",
 			ipfsData: types.IPFSData{
 				TaskData: &types.SendTaskDataToKeeper{
-					TaskID: 4,
+					TaskID: []int64{4},
 				},
 				ProofData: &types.ProofData{
 					TaskID:          4,
@@ -174,7 +174,7 @@ func TestTaskValidator_validateProofHash(t *testing.T) {
 			name: "valid proof hash",
 			ipfsData: types.IPFSData{
 				TaskData: &types.SendTaskDataToKeeper{
-					TaskID: 1,
+					TaskID: []int64{1},
 				},
 				ProofData: &types.ProofData{
 					TaskID:          1,
@@ -195,7 +195,7 @@ func TestTaskValidator_validateProofHash(t *testing.T) {
 			name: "missing task data",
 			ipfsData: types.IPFSData{
 				TaskData: &types.SendTaskDataToKeeper{
-					TaskID: 2,
+					TaskID: []int64{2},
 				},
 				ProofData: &types.ProofData{
 					TaskID:          2,

--- a/internal/keeper/core/validation/validator.go
+++ b/internal/keeper/core/validation/validator.go
@@ -31,9 +31,9 @@ func NewTaskValidator(alchemyAPIKey string, etherscanAPIKey string, dockerManage
 
 func (v *TaskValidator) ValidateTask(ctx context.Context, ipfsData types.IPFSData, traceID string) (bool, error) {
 	// check if the scheduler signature is valid
-	isSchedulerSignatureTrue, err := v.ValidateSchedulerSignature(ipfsData.TaskData, traceID)
-	if !isSchedulerSignatureTrue {
-		v.logger.Error("Scheduler signature validation failed", "task_id", ipfsData.TaskData.TaskID, "trace_id", traceID, "error", err)
+	isManagerSignatureTrue, err := v.ValidateManagerSignature(ipfsData.TaskData, traceID)
+	if !isManagerSignatureTrue {
+		v.logger.Error("Manager signature validation failed", "task_id", ipfsData.TaskData.TaskID, "trace_id", traceID, "error", err)
 		return false, err
 	}
 	v.logger.Info("Scheduler signature validation passed", "task_id", ipfsData.TaskData.TaskID, "trace_id", traceID)

--- a/internal/schedulers/condition/api/handlers/scheduler.go
+++ b/internal/schedulers/condition/api/handlers/scheduler.go
@@ -1,8 +1,9 @@
 package handlers
 
 import (
+	"fmt"
+	"math/big"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -79,8 +80,10 @@ func (h *SchedulerHandler) UnscheduleJob(c *gin.Context) {
 	h.logger.Info("[UnscheduleJob] trace_id=" + traceID + " - Unscheduling job")
 
 	jobIDStr := c.Param("job_id")
-	jobID, err := strconv.ParseInt(jobIDStr, 10, 64)
-	if err != nil {
+	jobID := new(big.Int)
+	_, ok := jobID.SetString(jobIDStr, 10)
+	if !ok {
+		err := fmt.Errorf("invalid job ID: %s", jobIDStr)
 		h.logger.Error("Invalid job ID", "job_id", jobIDStr, "error", err)
 		c.JSON(http.StatusBadRequest, gin.H{
 			"status":    "error",
@@ -121,8 +124,10 @@ func (h *SchedulerHandler) GetJobStats(c *gin.Context) {
 	h.logger.Info("[GetJobStats] trace_id=" + traceID + " - Getting job stats")
 
 	jobIDStr := c.Param("job_id")
-	jobID, err := strconv.ParseInt(jobIDStr, 10, 64)
-	if err != nil {
+	jobID := new(big.Int)
+	_, ok := jobID.SetString(jobIDStr, 10)
+	if !ok {
+		err := fmt.Errorf("invalid job ID: %s", jobIDStr)
 		h.logger.Error("Invalid job ID", "job_id", jobIDStr, "error", err)
 		c.JSON(http.StatusBadRequest, gin.H{
 			"status":    "error",
@@ -139,7 +144,7 @@ func (h *SchedulerHandler) GetJobStats(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{
 			"status":    "error",
 			"message":   "Condition job not found",
-			"error":     err.Error(),
+			"error":     "condition job not found",
 			"timestamp": time.Now().UTC(),
 		})
 		return

--- a/internal/schedulers/condition/api/handlers/scheduler.go
+++ b/internal/schedulers/condition/api/handlers/scheduler.go
@@ -134,8 +134,8 @@ func (h *SchedulerHandler) GetJobStats(c *gin.Context) {
 	}
 
 	stats := h.scheduler.GetStats()
-	if err != nil {
-		h.logger.Error("Failed to get condition job stats", "job_id", jobID, "error", err)
+	if stats == nil {
+		h.logger.Error("Failed to get condition job stats", "job_id", jobID)
 		c.JSON(http.StatusNotFound, gin.H{
 			"status":    "error",
 			"message":   "Condition job not found",
@@ -148,63 +148,6 @@ func (h *SchedulerHandler) GetJobStats(c *gin.Context) {
 	response := gin.H{
 		"status":    "success",
 		"data":      stats,
-		"timestamp": time.Now().UTC(),
-	}
-
-	c.JSON(http.StatusOK, response)
-}
-
-// UpdateJobsTask updates the task for a condition job
-func (h *SchedulerHandler) UpdateJobsTask(c *gin.Context) {
-	traceID := getTraceID(c)
-	h.logger.Info("[UpdateJobsTask] trace_id=" + traceID + " - Updating job's task")
-
-	jobIDStr := c.Param("job_id")
-	taskIDStr := c.Param("task_id")
-
-	jobID, err := strconv.ParseInt(jobIDStr, 10, 64)
-	if err != nil {
-		h.logger.Error("Invalid job ID", "job_id", jobIDStr, "error", err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"status":    "error",
-			"message":   "Invalid job ID",
-			"error":     err.Error(),
-			"timestamp": time.Now().UTC(),
-		})
-		return
-	}
-
-	taskID, err := strconv.ParseInt(taskIDStr, 10, 64)
-	if err != nil {
-		h.logger.Error("Invalid task ID", "task_id", taskIDStr, "error", err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"status":    "error",
-			"message":   "Invalid task ID",
-			"error":     err.Error(),
-			"timestamp": time.Now().UTC(),
-		})
-		return
-	}
-
-	// Update the task
-	if err := h.scheduler.UpdateJobTask(jobID, taskID); err != nil {
-		h.logger.Error("Failed to update condition job task", "job_id", jobID, "task_id", taskID, "error", err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"status":    "error",
-			"message":   "Failed to update condition job task",
-			"error":     err.Error(),
-			"timestamp": time.Now().UTC(),
-		})
-		return
-	}
-
-	h.logger.Info("Condition job task updated successfully", "job_id", jobID, "task_id", taskID)
-
-	response := gin.H{
-		"status":    "success",
-		"message":   "Condition job task updated successfully",
-		"job_id":    jobID,
-		"task_id":   taskID,
 		"timestamp": time.Now().UTC(),
 	}
 

--- a/internal/schedulers/condition/api/server.go
+++ b/internal/schedulers/condition/api/server.go
@@ -104,8 +104,6 @@ func (s *Server) setupRoutes(deps Dependencies) {
 		api.POST("/job/schedule", schedulerHandler.ScheduleJob)
 		api.POST("/job/pause", schedulerHandler.UnscheduleJob)
 		api.GET("/job/stats/:job_id", schedulerHandler.GetJobStats)
-
-		api.PUT("/job/task/:job_id/:task_id", schedulerHandler.UpdateJobsTask)
 	}
 }
 

--- a/internal/schedulers/condition/scheduler/init.go
+++ b/internal/schedulers/condition/scheduler/init.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/trigg3rX/triggerx-backend/internal/schedulers/condition/config"
@@ -23,9 +25,9 @@ type ConditionBasedScheduler struct {
 	ctx                     context.Context
 	cancel                  context.CancelFunc
 	logger                  logging.Logger
-	conditionWorkers        map[int64]*worker.ConditionWorker         // jobID -> condition worker
-	eventWorkers            map[int64]*worker.EventWorker             // jobID -> event worker
-	jobDataStore            map[int64]*types.ScheduleConditionJobData // jobID -> job data for trigger notifications
+	conditionWorkers        map[*big.Int]*worker.ConditionWorker         // jobID -> condition worker
+	eventWorkers            map[*big.Int]*worker.EventWorker             // jobID -> event worker
+	jobDataStore            map[*big.Int]*types.ScheduleConditionJobData // jobID -> job data for trigger notifications
 	workersMutex            sync.RWMutex
 	chainClients            map[string]*ethclient.Client // chainID -> client
 	HTTPClient              *retry.HTTPClient
@@ -55,9 +57,9 @@ func NewConditionBasedScheduler(managerID string, logger logging.Logger, dbClien
 		ctx:                     ctx,
 		cancel:                  cancel,
 		logger:                  logger,
-		conditionWorkers:        make(map[int64]*worker.ConditionWorker),
-		eventWorkers:            make(map[int64]*worker.EventWorker),
-		jobDataStore:            make(map[int64]*types.ScheduleConditionJobData),
+		conditionWorkers:        make(map[*big.Int]*worker.ConditionWorker),
+		eventWorkers:            make(map[*big.Int]*worker.EventWorker),
+		jobDataStore:            make(map[*big.Int]*types.ScheduleConditionJobData),
 		chainClients:            make(map[string]*ethclient.Client),
 		dbClient:                dbClient,
 		httpClient:              httpClient,
@@ -127,9 +129,9 @@ func (s *ConditionBasedScheduler) Stop() {
 		worker.Stop()
 		s.logger.Info("Stopped event worker", "job_id", jobID)
 	}
-	s.conditionWorkers = make(map[int64]*worker.ConditionWorker)
-	s.eventWorkers = make(map[int64]*worker.EventWorker)
-	s.jobDataStore = make(map[int64]*types.ScheduleConditionJobData)
+	s.conditionWorkers = make(map[*big.Int]*worker.ConditionWorker)
+	s.eventWorkers = make(map[*big.Int]*worker.EventWorker)
+	s.jobDataStore = make(map[*big.Int]*types.ScheduleConditionJobData)
 	s.workersMutex.Unlock()
 
 	// Close chain clients

--- a/internal/schedulers/condition/scheduler/schedule.go
+++ b/internal/schedulers/condition/scheduler/schedule.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -305,7 +306,7 @@ func (s *ConditionBasedScheduler) submitTriggeredTaskToTaskManager(jobData *type
 // createTriggerDataFromNotification creates appropriate trigger data based on job type
 func (s *ConditionBasedScheduler) createTriggerDataFromNotification(jobData *types.ScheduleConditionJobData, notification *worker.TriggerNotification) types.TaskTriggerData {
 	baseTriggerData := types.TaskTriggerData{
-		TaskID:                  notification.JobID,
+		TaskID:                  jobData.TaskTargetData.TaskID,
 		TaskDefinitionID:        jobData.TaskDefinitionID,
 		CurrentTriggerTimestamp: notification.TriggeredAt,
 	}
@@ -334,7 +335,7 @@ func (s *ConditionBasedScheduler) createTriggerDataFromNotification(jobData *typ
 }
 
 // submitTaskToTaskManager submits the task to TaskManager via HTTP
-func (s *ConditionBasedScheduler) submitTaskToTaskManager(request types.SchedulerTaskRequest, taskID int64) (bool, error) {
+func (s *ConditionBasedScheduler) submitTaskToTaskManager(request types.SchedulerTaskRequest, taskID *big.Int) (bool, error) {
 	startTime := time.Now()
 
 	// Marshal request to JSON
@@ -413,7 +414,7 @@ func (s *ConditionBasedScheduler) submitTaskToTaskManager(request types.Schedule
 }
 
 // UnscheduleJob stops and removes a condition worker
-func (s *ConditionBasedScheduler) UnscheduleJob(jobID int64) error {
+func (s *ConditionBasedScheduler) UnscheduleJob(jobID *big.Int) error {
 	s.workersMutex.Lock()
 	defer s.workersMutex.Unlock()
 

--- a/internal/schedulers/condition/scheduler/schedule.go
+++ b/internal/schedulers/condition/scheduler/schedule.go
@@ -448,28 +448,3 @@ func (s *ConditionBasedScheduler) UnscheduleJob(jobID int64) error {
 	s.logger.Info("Job unscheduled successfully", "job_id", jobID)
 	return nil
 }
-
-// Legacy method - Deprecated: Now handled by Redis orchestration
-func (s *ConditionBasedScheduler) SendTaskToPerformer(jobData *types.ScheduleConditionJobData, notification *worker.TriggerNotification) (bool, error) {
-	s.logger.Warn("SendTaskToPerformer is deprecated - triggered tasks are now handled by Redis orchestration")
-	// Redirect to new Redis-based approach
-	return s.submitTriggeredTaskToRedis(jobData, &worker.TriggerNotification{
-		JobID:         jobData.JobID,
-		TriggerValue:  0, // Convert as needed
-		TriggerTxHash: "",
-		TriggeredAt:   time.Now(),
-	})
-}
-
-// UpdateJobTask updates the task for a condition job
-// Deprecated: Tasks are now automatically managed by Redis orchestration
-func (s *ConditionBasedScheduler) UpdateJobTask(jobID, taskID int64) error {
-	s.logger.Warn("UpdateJobTask is deprecated - tasks are now automatically managed by Redis orchestration",
-		"job_id", jobID,
-		"task_id", taskID,
-	)
-
-	// In the new architecture, tasks are automatically created and managed by Redis
-	// when conditions are triggered, so manual task updates are not supported
-	return fmt.Errorf("manual task updates are not supported in Redis orchestration mode - tasks are automatically managed when conditions trigger")
-}

--- a/internal/schedulers/condition/scheduler/schedule.go
+++ b/internal/schedulers/condition/scheduler/schedule.go
@@ -308,23 +308,26 @@ func (s *ConditionBasedScheduler) createTriggerDataFromNotification(jobData *typ
 		TaskID:                  notification.JobID,
 		TaskDefinitionID:        jobData.TaskDefinitionID,
 		CurrentTriggerTimestamp: notification.TriggeredAt,
-		ExpirationTime:          jobData.EventWorkerData.ExpirationTime,
 	}
 
 	switch jobData.TaskDefinitionID {
 	case 5, 6: // Condition-based
+		baseTriggerData.ExpirationTime = jobData.ConditionWorkerData.ExpirationTime
 		baseTriggerData.ConditionSatisfiedValue = int(notification.TriggerValue)
 		baseTriggerData.ConditionType = jobData.ConditionWorkerData.ConditionType
 		baseTriggerData.ConditionSourceType = jobData.ConditionWorkerData.ValueSourceType
 		baseTriggerData.ConditionSourceUrl = jobData.ConditionWorkerData.ValueSourceUrl
 		baseTriggerData.ConditionUpperLimit = int(jobData.ConditionWorkerData.UpperLimit)
 		baseTriggerData.ConditionLowerLimit = int(jobData.ConditionWorkerData.LowerLimit)
+		s.logger.Info("Condition job expiration time", "expiration_time", jobData.ConditionWorkerData.ExpirationTime)
 
 	case 3, 4: // Event-based
+		baseTriggerData.ExpirationTime = jobData.EventWorkerData.ExpirationTime
 		baseTriggerData.EventTxHash = notification.TriggerTxHash
 		baseTriggerData.EventChainId = jobData.EventWorkerData.TriggerChainID
 		baseTriggerData.EventTriggerContractAddress = jobData.EventWorkerData.TriggerContractAddress
 		baseTriggerData.EventTriggerName = jobData.EventWorkerData.TriggerEvent
+		s.logger.Info("Event job expiration time", "expiration_time", jobData.EventWorkerData.ExpirationTime)
 	}
 
 	return baseTriggerData

--- a/internal/schedulers/condition/scheduler/stats.go
+++ b/internal/schedulers/condition/scheduler/stats.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"fmt"
+	"math/big"
 )
 
 // GetStats returns current scheduler statistics
@@ -136,7 +137,7 @@ func (s *ConditionBasedScheduler) GetStats() map[string]interface{} {
 }
 
 // GetConditionWorkerStats returns statistics for a specific condition worker
-func (s *ConditionBasedScheduler) GetConditionWorkerStats(jobID int64) (map[string]interface{}, error) {
+func (s *ConditionBasedScheduler) GetConditionWorkerStats(jobID *big.Int) (map[string]interface{}, error) {
 	s.workersMutex.RLock()
 	defer s.workersMutex.RUnlock()
 
@@ -162,7 +163,7 @@ func (s *ConditionBasedScheduler) GetConditionWorkerStats(jobID int64) (map[stri
 }
 
 // GetEventWorkerStats returns statistics for a specific event worker
-func (s *ConditionBasedScheduler) GetEventWorkerStats(jobID int64) (map[string]interface{}, error) {
+func (s *ConditionBasedScheduler) GetEventWorkerStats(jobID *big.Int) (map[string]interface{}, error) {
 	s.workersMutex.RLock()
 	defer s.workersMutex.RUnlock()
 

--- a/internal/schedulers/condition/scheduler/worker/types.go
+++ b/internal/schedulers/condition/scheduler/worker/types.go
@@ -1,6 +1,9 @@
 package worker
 
-import "time"
+import (
+	"math/big"
+	"time"
+)
 
 const (
 	PerformerLockTTL         = 15 * time.Minute // Lock duration for condition monitoring
@@ -43,7 +46,7 @@ type ValueResponse struct {
 
 // ConditionTriggerNotification represents a notification from a worker when a condition is satisfied
 type TriggerNotification struct {
-	JobID           int64     `json:"job_id"`
+	JobID           *big.Int     `json:"job_id"`
 	TriggerTxHash   string    `json:"trigger_tx_hash"`
 	TriggerValue    float64   `json:"trigger_value"`
 	TriggeredAt     time.Time `json:"triggered_at"`

--- a/internal/taskmanager/streams/performers/performers.go
+++ b/internal/taskmanager/streams/performers/performers.go
@@ -27,9 +27,13 @@ const (
 func GetPerformerData() types.PerformerData {
 	// TODO: Replace with actual performer selection logic
 	// For now, returning a fixed performer as mentioned in the scheduler code
+	// return types.PerformerData{
+	// 	KeeperID:      3,
+	// 	KeeperAddress: "0x0a067a261c5f5e8c4c0b9137430b4fe1255eb62e",
+	// }
 	return types.PerformerData{
-		KeeperID:      3,
-		KeeperAddress: "0x0a067a261c5f5e8c4c0b9137430b4fe1255eb62e",
+		KeeperID:      2,
+		KeeperAddress: "0x011fcbae5f306cd793456ab7d4c0cc86756c693d",
 	}
 }
 

--- a/internal/taskmanager/streams/tasks/task_read.go
+++ b/internal/taskmanager/streams/tasks/task_read.go
@@ -21,7 +21,7 @@ func (tsm *TaskStreamManager) getTaskStreamData(taskID int64) (*TaskStreamData, 
 	}
 
 	for _, task := range taskStreamData {
-		if task.SendTaskDataToKeeper.TaskID == taskID {
+		if task.SendTaskDataToKeeper.TaskID[0] == taskID {
 			return &task, nil
 		}
 	}
@@ -53,12 +53,12 @@ func (tsm *TaskStreamManager) ReadTasksFromRetryStream(consumerGroup, consumerNa
 		if task.ScheduledFor == nil || task.ScheduledFor.Before(now) {
 			readyTasks = append(readyTasks, task)
 			tsm.logger.Debug("Task ready for retry",
-				"task_id", task.SendTaskDataToKeeper.TaskID,
+				"task_id", task.SendTaskDataToKeeper.TaskID[0],
 				"retry_count", task.RetryCount,
 				"scheduled_for", task.ScheduledFor)
 		} else {
 			tsm.logger.Debug("Task not yet ready for retry",
-				"task_id", task.SendTaskDataToKeeper.TaskID,
+				"task_id", task.SendTaskDataToKeeper.TaskID[0],
 				"scheduled_for", task.ScheduledFor,
 				"time_remaining", task.ScheduledFor.Sub(now))
 		}
@@ -139,7 +139,7 @@ func (tsm *TaskStreamManager) readTasksFromStream(stream, consumerGroup, consume
 
 			tasks = append(tasks, task)
 			tsm.logger.Debug("Task read from stream",
-				"task_id", task.SendTaskDataToKeeper.TaskID,
+				"task_id", task.SendTaskDataToKeeper.TaskID[0],
 				"stream", stream.Stream,
 				"message_id", message.ID)
 		}

--- a/internal/taskmanager/streams/tasks/task_receive.go
+++ b/internal/taskmanager/streams/tasks/task_receive.go
@@ -10,7 +10,7 @@ import (
 func (tsm *TaskStreamManager) UpdateDatabase(ipfsData types.IPFSData) {
 	tsm.logger.Info("Updating task stream and database ...")
 
-	taskID := ipfsData.TaskData.TaskID
+	taskID := ipfsData.TaskData.TaskID[0]
 	taskStreamData, err := tsm.getTaskStreamData(taskID)
 	if err != nil {
 		tsm.logger.Error("Failed to read task stream data", "error", err)
@@ -34,7 +34,7 @@ func (tsm *TaskStreamManager) UpdateDatabase(ipfsData types.IPFSData) {
 
 	// Update task execution data in Database
 	updateTaskExecutionData := types.UpdateTaskExecutionDataRequest{
-		TaskID: ipfsData.TaskData.TaskID,
+		TaskID: ipfsData.TaskData.TaskID[0],
 		TaskPerformerID: ipfsData.TaskData.PerformerData.KeeperID,
 		ExecutionTimestamp: ipfsData.ActionData.ExecutionTimestamp,
 		ExecutionTxHash: ipfsData.ActionData.ActionTxHash,

--- a/internal/taskmanager/streams/tasks/types.go
+++ b/internal/taskmanager/streams/tasks/types.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"math/big"
 	"time"
 
 	"github.com/trigg3rX/triggerx-backend/pkg/types"
@@ -27,7 +28,7 @@ const (
 
 // TaskStreamData represents task information for Redis-managed task streams
 type TaskStreamData struct {
-	JobID            int64     `json:"job_id"`
+	JobID            *big.Int     `json:"job_id"`
 	TaskDefinitionID int       `json:"task_definition_id"`
 	CreatedAt        time.Time `json:"created_at"`
 

--- a/othentic/docker-compose.yaml
+++ b/othentic/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
       "--internal-tasks",
       "--metrics",
       "--delay", "10000",
+      "--aggregator.simulate-transactions", "true",
       "--metrics.port", "${AGGREGATOR_METRICS_PORT}",
       "--announced-addresses", "/ip4/${PUBLIC_IPV4_ADDRESS}/tcp/${AGGREGATOR_P2P_PORT}/p2p/${OTHENTIC_BOOTSTRAP_ID}"
     ]

--- a/pkg/docker/execution/executor.go
+++ b/pkg/docker/execution/executor.go
@@ -20,8 +20,11 @@ type CodeExecutor struct {
 }
 
 func NewCodeExecutor(ctx context.Context, cfg config.ExecutorConfig, logger logging.Logger) (*CodeExecutor, error) {
-	// Create Docker client
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	// Create Docker client with API version compatibility
+	cli, err := client.NewClientWithOpts(
+		client.FromEnv,
+		client.WithVersion("1.44"),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create docker client: %w", err)
 	}

--- a/pkg/proof/proof.go
+++ b/pkg/proof/proof.go
@@ -142,7 +142,7 @@ func GenerateProof(ipfsData types.IPFSData, connState *tls.ConnectionState) (typ
 
 	// Create enhanced proof with additional TLS information
 	proofData := types.ProofData{
-		TaskID:               ipfsData.TaskData.TaskID,
+		TaskID:               ipfsData.TaskData.TaskID[0],
 		ProofOfTask:          proofHashStr,
 		CertificateHash:      certHashStr,
 		CertificateTimestamp: time.Now().UTC(),

--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -13,7 +13,7 @@ func TestGenerateProofWithTLSConnection(t *testing.T) {
 	// Create sample IPFS data for testing
 	ipfsData := types.IPFSData{
 		TaskData: &types.SendTaskDataToKeeper{
-			TaskID: 123,
+			TaskID: []int64{123},
 		},
 		ActionData: &types.PerformerActionData{
 			TaskID:             123,
@@ -33,7 +33,7 @@ func TestGenerateProofWithTLSConnection(t *testing.T) {
 	}
 
 	// Validate proof data
-	if proofData.TaskID != ipfsData.TaskData.TaskID {
+	if proofData.TaskID != ipfsData.TaskData.TaskID[0] {
 		t.Errorf("Expected TaskID %d, got %d", ipfsData.TaskData.TaskID, proofData.TaskID)
 	}
 
@@ -56,7 +56,7 @@ func TestGenerateProofWithMockCert(t *testing.T) {
 	// Create sample IPFS data for testing
 	ipfsData := types.IPFSData{
 		TaskData: &types.SendTaskDataToKeeper{
-			TaskID: 456,
+			TaskID: []int64{456},
 		},
 		ActionData: &types.PerformerActionData{
 			TaskID:             456,
@@ -84,7 +84,7 @@ func TestGenerateProofWithMockCert(t *testing.T) {
 	}
 
 	// Validate proof data
-	if proofData.TaskID != ipfsData.TaskData.TaskID {
+	if proofData.TaskID != ipfsData.TaskData.TaskID[0] {
 		t.Errorf("Expected TaskID %d, got %d", ipfsData.TaskData.TaskID, proofData.TaskID)
 	}
 

--- a/pkg/types/dbserver_create.go
+++ b/pkg/types/dbserver_create.go
@@ -66,13 +66,13 @@ type CreateJobResponse struct {
 
 // Create New Task
 type CreateTaskRequest struct {
-	JobID            int64 `json:"job_id" validate:"required"`
+	JobID            *big.Int `json:"job_id" validate:"required"`
 	TaskDefinitionID int   `json:"task_definition_id" validate:"required"`
 }
 
 type CreateTaskResponse struct {
 	TaskID           int64 `json:"task_id"`
-	JobID            int64 `json:"job_id"`
+	JobID            *big.Int `json:"job_id"`
 	TaskDefinitionID int   `json:"task_definition_id"`
 }
 

--- a/pkg/types/dbserver_create.go
+++ b/pkg/types/dbserver_create.go
@@ -66,16 +66,14 @@ type CreateJobResponse struct {
 
 // Create New Task
 type CreateTaskRequest struct {
-	JobID            *big.Int `json:"job_id" validate:"required"`
-	TaskDefinitionID int      `json:"task_definition_id" validate:"required"`
-	TaskPerformerID  int64    `json:"task_performer_id" validate:"required"`
+	JobID            int64 `json:"job_id" validate:"required"`
+	TaskDefinitionID int   `json:"task_definition_id" validate:"required"`
 }
 
 type CreateTaskResponse struct {
-	TaskID           int64    `json:"task_id"`
-	JobID            *big.Int `json:"job_id"`
-	TaskDefinitionID int      `json:"task_definition_id"`
-	TaskPerformerID  int64    `json:"task_performer_id"`
+	TaskID           int64 `json:"task_id"`
+	JobID            int64 `json:"job_id"`
+	TaskDefinitionID int   `json:"task_definition_id"`
 }
 
 // Create New Keeper from Contracts (registrar)

--- a/pkg/types/schedulers.go
+++ b/pkg/types/schedulers.go
@@ -94,19 +94,30 @@ type TaskTriggerData struct {
 	ConditionSatisfiedValue int    `json:"condition_satisfied_value"`
 }
 
-type SchedulerSignatureData struct {
-	TaskID                  int64  `json:"task_id"`
-	SchedulerID             int    `json:"scheduler_id"`
-	SchedulerSigningAddress string `json:"scheduler_signing_address"`
-	SchedulerSignature      string `json:"scheduler_signature"`
-}
-
 type SendTaskDataToKeeper struct {
-	TaskID             int64                   `json:"task_id"`
+	TaskID             []int64                   `json:"task_id"`
 	PerformerData      PerformerData           `json:"performer_data"`
 	TargetData         []TaskTargetData        `json:"target_data"`
 	TriggerData        []TaskTriggerData       `json:"trigger_data"`
-	SchedulerSignature *SchedulerSignatureData `json:"scheduler_signature_data"`
+	SchedulerID        int                     `json:"scheduler_id"`
+	ManagerSignature   string                  `json:"manager_signature"`
+}
+
+// SchedulerTaskRequest represents the request format for TaskManager
+type SchedulerTaskRequest struct {
+	SendTaskDataToKeeper SendTaskDataToKeeper `json:"send_task_data_to_keeper"`
+	Source               string             `json:"source"`
+}
+
+// TaskManagerAPIResponse represents the response from TaskManager
+type TaskManagerAPIResponse struct {
+	Success   bool                `json:"success"`
+	TaskID    []int64             `json:"task_id"`
+	Message   string              `json:"message"`
+	Performer PerformerData `json:"performer"`
+	Timestamp string              `json:"timestamp"`
+	Error     string              `json:"error,omitempty"`
+	Details   string              `json:"details,omitempty"`
 }
 
 type BroadcastDataForPerformer struct {


### PR DESCRIPTION
# Pull Request

## Features
- `internal/keeper/core/execution/`: Add nonceManager for task executions. It maintains nonce for multiple chains and prevents transactions from being cancelled out due to nonce errors (or replacement transactions).
- Update signing and validation scheme for batch tasks:
    - Batch of tasks now has an array of taskID, trigger, target and managerSignature data, for easy processing at keeper's end.
    - Tasks can be sent to performers in batches, and validation can be done for each task as they are executed, making validation less delayed.
    - Switched to managerSignature instead of schedulerSignature.
    - The list of valid Manager Addresses can be passed through Health Check-In from Keeper.

## Fixes
- `internal/health/health.go`: Update to accept all keepers from 0.1.0
- `internal/schedulers/condition/`: 
    - Drop UpdateJobStatus function and its use. TaskManager handles the TaskIds for JobIds.
    - Create task in DB before passing data to TaskManager
    - Pass expiration time correctly from worker to TaskManager
- `cmd/keeper/main.go`: Pass dependencies as value, to prevent copies and race conditions.
- `Dockerfile.keeper`: Update for older Docker API version compatibility.