### PR TITLE
Feature: Allow `task_error` to be visible to job creator.

### DIFF
--- a/internal/dbserver/events/task_events.go
+++ b/internal/dbserver/events/task_events.go
@@ -50,6 +50,7 @@ type TaskUpdatedEvent struct {
 	TaskSubmissionTxHash *string    `json:"task_submission_tx_hash,omitempty"`
 	IsSuccessful         *bool      `json:"is_successful,omitempty"`
 	TaskStatus           *string    `json:"task_status,omitempty"`
+	TaskError            *string    `json:"task_error,omitempty"`
 	UserID               string     `json:"user_id,omitempty"`
 }
 

--- a/internal/dbserver/handlers/job_status_script.go
+++ b/internal/dbserver/handlers/job_status_script.go
@@ -53,7 +53,7 @@ func (c *JobStatusChecker) checkJobStatuses() {
 	currentTime := time.Now()
 
 	//log the current time and checking for jobs
-	c.logger.Info(fmt.Sprintf("Checking for jobs at %s", currentTime.Format(time.RFC3339)))
+	// c.logger.Info(fmt.Sprintf("Checking for jobs at %s", currentTime.Format(time.RFC3339)))
 
 	// Check event jobs
 	wg.Add(1)
@@ -78,7 +78,7 @@ func (c *JobStatusChecker) checkJobStatuses() {
 
 	wg.Wait()
 
-	c.logger.Info("Job status check completed")
+	// c.logger.Info("Job status check completed")
 }
 
 // checkEventJobs checks all active event jobs for expiration

--- a/internal/dbserver/handlers/task_read.go
+++ b/internal/dbserver/handlers/task_read.go
@@ -1,8 +1,8 @@
 package handlers
 
 import (
-	"math/big"
 	"fmt"
+	"math/big"
 	"net/http"
 	"strconv"
 
@@ -98,7 +98,8 @@ func (h *Handler) GetTasksByJobID(c *gin.Context) {
 			TaskAttesterIDs:    task.TaskAttesterIDs,
 			IsAccepted:         task.IsAccepted,
 			TaskStatus:         task.TaskStatus,
-			ConvertedArguments:  task.ConvertedArguments ,
+			TaskError:          task.TaskError,
+			ConvertedArguments: task.ConvertedArguments,
 		}
 	}
 	//find the created_chain id for the job using jobIDBig from database

--- a/internal/dbserver/handlers/time_jobs.go
+++ b/internal/dbserver/handlers/time_jobs.go
@@ -62,6 +62,8 @@ func (h *Handler) GetTimeBasedTasks(c *gin.Context) {
 		tasks[i].TaskID = taskID
 	}
 
-	h.logger.Infof("[GetTimeBasedJobs] Successfully retrieved %d time based jobs", len(tasks))
+	if len(tasks) != 0 {
+		h.logger.Infof("[GetTimeBasedJobs] Successfully retrieved %d time based jobs", len(tasks))
+	}
 	c.JSON(http.StatusOK, tasks)
 }

--- a/internal/dbserver/handlers/websocket_initial_data_handler.go
+++ b/internal/dbserver/handlers/websocket_initial_data_handler.go
@@ -1,8 +1,8 @@
 package handlers
 
 import (
-	"math/big"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/trigg3rX/triggerx-backend/internal/dbserver/repository"
@@ -74,7 +74,8 @@ func (h *InitialDataHandler) handleJobRoomSubscription(room string, client *webs
 			IsAccepted:         task.IsAccepted,
 			TxURL:              task.TxURL,
 			TaskStatus:         task.TaskStatus,
-			ConvertedArguments:  task.ConvertedArguments ,
+			TaskError:          task.TaskError,
+			ConvertedArguments: task.ConvertedArguments,
 		}
 	}
 

--- a/internal/dbserver/repository/queries/task_queries.go
+++ b/internal/dbserver/repository/queries/task_queries.go
@@ -51,13 +51,13 @@ const (
                task_opx_cost, execution_timestamp, execution_tx_hash, task_performer_id, 
 			   proof_of_task, converted_arguments, task_attester_ids,
 			   tp_signature, ta_signature, task_submission_tx_hash,
-			   is_successful, task_status, is_imua
+			   is_successful, task_status, task_error, is_imua
         FROM triggerx.task_data
         WHERE task_id = ?`
 
 	GetTasksByJobIDQuery = `
 		SELECT task_id, task_number, task_opx_cost, execution_timestamp, execution_tx_hash, task_performer_id, 
-			   task_attester_ids, is_accepted, task_status, converted_arguments
+			   task_attester_ids, is_accepted, task_status, task_error, converted_arguments
 		FROM triggerx.task_data
 		WHERE job_id = ? ALLOW FILTERING`
 

--- a/internal/dbserver/repository/task_repository.go
+++ b/internal/dbserver/repository/task_repository.go
@@ -164,7 +164,7 @@ func (r *taskRepository) UpdateTaskNumberAndStatus(taskID int64, taskNumber int6
 func (r *taskRepository) GetTaskDataByID(taskID int64) (commonTypes.TaskData, error) {
 	var task commonTypes.TaskData
 	var jobIDBigInt *big.Int
-	err := r.db.Session().Query(queries.GetTaskDataByIDQuery, taskID).Scan(&task.TaskID, &task.TaskNumber, &jobIDBigInt, &task.TaskDefinitionID, &task.CreatedAt, &task.TaskOpxCost, &task.ExecutionTimestamp, &task.ExecutionTxHash, &task.TaskPerformerID, &task.ProofOfTask, &task.ConvertedArguments, &task.TaskAttesterIDs, &task.TpSignature, &task.TaSignature, &task.TaskSubmissionTxHash, &task.IsAccepted, &task.TaskStatus, &task.IsImua)
+	err := r.db.Session().Query(queries.GetTaskDataByIDQuery, taskID).Scan(&task.TaskID, &task.TaskNumber, &jobIDBigInt, &task.TaskDefinitionID, &task.CreatedAt, &task.TaskOpxCost, &task.ExecutionTimestamp, &task.ExecutionTxHash, &task.TaskPerformerID, &task.ProofOfTask, &task.ConvertedArguments, &task.TaskAttesterIDs, &task.TpSignature, &task.TaSignature, &task.TaskSubmissionTxHash, &task.IsAccepted, &task.TaskStatus, &task.TaskError, &task.IsImua)
 	if err != nil {
 		return commonTypes.TaskData{}, errors.New("error getting task data by ID")
 	}
@@ -187,6 +187,7 @@ func (r *taskRepository) GetTasksByJobID(jobID *big.Int) ([]types.GetTasksByJobI
 		&task.TaskAttesterIDs,
 		&task.IsAccepted,
 		&task.TaskStatus,
+		&task.TaskError,
 		&task.ConvertedArguments,
 	) {
 		tasks = append(tasks, task)

--- a/internal/dbserver/types/task_types.go
+++ b/internal/dbserver/types/task_types.go
@@ -39,6 +39,7 @@ type TasksByJobIDResponse struct {
 	TaskPerformerID    int64     `json:"task_performer_id"`
 	TaskAttesterIDs    []int64   `json:"task_attester_ids"`
 	TaskStatus         string    `json:"task_status"`
+	TaskError          string    `json:"task_error"`
 	IsAccepted         bool      `json:"is_accepted"`
 	TxURL              string    `json:"tx_url"`
 	ConvertedArguments []string  `json:"converted_arguments"`
@@ -55,5 +56,6 @@ type GetTasksByJobID struct {
 	IsAccepted         bool      `json:"is_accepted"`
 	TxURL              string    `json:"tx_url"`
 	TaskStatus         string    `json:"task_status"`
+	TaskError          string    `json:"task_error"`
 	ConvertedArguments []string  `json:"converted_arguments"`
 }

--- a/internal/dbserver/websocket/message.go
+++ b/internal/dbserver/websocket/message.go
@@ -78,6 +78,7 @@ type JobTaskSnapshotData struct {
 	TaskPerformerID    int64     `json:"task_performer_id"`
 	TaskAttesterIDs    []int64   `json:"task_attester_ids"`
 	TaskStatus         string    `json:"task_status"`
+	TaskError          string    `json:"task_error"`
 	IsAccepted         bool      `json:"is_accepted"`
 	TxURL              string    `json:"tx_url"`
 	ConvertedArguments []string  `json:"converted_arguments"`

--- a/internal/keeper/client/taskmonitor/client.go
+++ b/internal/keeper/client/taskmonitor/client.go
@@ -1,0 +1,109 @@
+package taskmonitor
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/trigg3rX/triggerx-backend/internal/keeper/config"
+	"github.com/trigg3rX/triggerx-backend/pkg/cryptography"
+	"github.com/trigg3rX/triggerx-backend/pkg/logging"
+	"github.com/trigg3rX/triggerx-backend/pkg/rpc/client"
+)
+
+// Client represents a client for communicating with the taskmonitor service
+type Client struct {
+	rpcClient *client.Client
+	logger    logging.Logger
+}
+
+// NewClient creates a new taskmonitor client
+func NewClient(logger logging.Logger) (*Client, error) {
+	rpcUrl := config.GetTaskMonitorRPCUrl()
+	if rpcUrl == "" {
+		return nil, fmt.Errorf("task monitor RPC URL is not configured")
+	}
+
+	rpcClient := client.NewClient(client.Config{
+		ServiceName: rpcUrl,
+		Timeout:     30 * time.Second,
+		MaxRetries:  3,
+		RetryDelay:  time.Second,
+		PoolSize:    10,
+		PoolTimeout: 5 * time.Second,
+	}, logger)
+
+	return &Client{
+		rpcClient: rpcClient,
+		logger:    logger,
+	}, nil
+}
+
+// ReportTaskErrorRequest represents the request to report a task error
+type ReportTaskErrorRequest struct {
+	TaskID        int64  `json:"task_id"`
+	KeeperAddress string `json:"keeper_address"`
+	Error         string `json:"error"`
+	Signature     string `json:"signature"`
+}
+
+// ReportTaskErrorResponse represents the response from taskmonitor
+type ReportTaskErrorResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+}
+
+// ReportTaskError reports a task execution error to taskmonitor
+func (c *Client) ReportTaskError(ctx context.Context, taskID int64, errorMsg string) error {
+	keeperAddress := config.GetKeeperAddress()
+
+	// Create request data for signing (without signature field)
+	signData := struct {
+		TaskID        int64  `json:"task_id"`
+		KeeperAddress string `json:"keeper_address"`
+		Error         string `json:"error"`
+	}{
+		TaskID:        taskID,
+		KeeperAddress: keeperAddress,
+		Error:         errorMsg,
+	}
+
+	// Sign the request data
+	signature, err := cryptography.SignJSONMessage(signData, config.GetPrivateKeyConsensus())
+	if err != nil {
+		return fmt.Errorf("failed to sign error report: %w", err)
+	}
+
+	// Create request
+	request := ReportTaskErrorRequest{
+		TaskID:        taskID,
+		KeeperAddress: keeperAddress,
+		Error:         errorMsg,
+		Signature:     signature,
+	}
+
+	// Make RPC call
+	var response ReportTaskErrorResponse
+	err = c.rpcClient.Call(ctx, "report-task-error", &request, &response)
+	if err != nil {
+		return fmt.Errorf("RPC call failed: %w", err)
+	}
+
+	if !response.Success {
+		return fmt.Errorf("taskmonitor reported failure: %s", response.Message)
+	}
+
+	c.logger.Info("Task error reported successfully to taskmonitor",
+		"task_id", taskID,
+		"error", errorMsg)
+
+	return nil
+}
+
+// Close closes the taskmonitor client
+func (c *Client) Close() error {
+	if c.rpcClient != nil {
+		return c.rpcClient.Close()
+	}
+	return nil
+}

--- a/internal/keeper/config/config.go
+++ b/internal/keeper/config/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	// Backend Service URLs
 	aggregatorRPCUrl string
 	healthRPCUrl     string
+	taskMonitorRPCUrl string
 
 	l1Chain string
 	l2Chain string
@@ -96,6 +97,7 @@ func Init() error {
 		grafanaPort:              env.GetEnvString("GRAFANA_PORT", "3000"),
 		aggregatorRPCUrl:         env.GetEnvString("OTHENTIC_CLIENT_RPC_ADDRESS", "https://aggregator.triggerx.network"),
 		healthRPCUrl:             env.GetEnvString("HEALTH_IP_ADDRESS", "https://health.triggerx.network"),
+		taskMonitorRPCUrl:        env.GetEnvString("TASK_MONITOR_RPC_URL", "https://task.triggerx.network"),
 		tlsProofHost:             "www.google.com",
 		tlsProofPort:             "443",
 		// l1Chain:                  env.GetEnvString("L1_CHAIN", "11155111"),
@@ -214,6 +216,10 @@ func GetAggregatorRPCUrl() string {
 
 func GetHealthRPCUrl() string {
 	return cfg.healthRPCUrl
+}
+
+func GetTaskMonitorRPCUrl() string {
+	return cfg.taskMonitorRPCUrl
 }
 
 func GetAvsGovernanceAddress() string {

--- a/internal/keeper/core/execution/action.go
+++ b/internal/keeper/core/execution/action.go
@@ -78,7 +78,7 @@ func (e *TaskExecutor) executeAction(targetData *types.TaskTargetData, triggerDa
 	// Handle args as potentially structured data
 	convertedArgs, err := e.processArguments(argData, method.Inputs, contractABI)
 	if err != nil {
-		return types.PerformerActionData{}, fmt.Errorf("error processing arguments: %v", err)
+		return types.PerformerActionData{}, fmt.Errorf("error processing (dynamic) arguments: %v", err)
 	}
 
 	// Pack the target contract's function call data
@@ -86,7 +86,7 @@ func (e *TaskExecutor) executeAction(targetData *types.TaskTargetData, triggerDa
 	callData, err = contractABI.Pack(method.Name, convertedArgs...)
 	if err != nil {
 		e.logger.Warnf("Error packing arguments: %v", err)
-		return types.PerformerActionData{}, fmt.Errorf("error packing arguments: %v", err)
+		return types.PerformerActionData{}, fmt.Errorf("error packing arguments to function call: %v", err)
 	}
 
 	// Create transaction data for execution contract
@@ -137,7 +137,7 @@ func (e *TaskExecutor) executeAction(targetData *types.TaskTargetData, triggerDa
 		privateKey,
 	)
 	if err != nil {
-		return types.PerformerActionData{}, err
+		return types.PerformerActionData{}, fmt.Errorf("failed to submit transaction: %v", err)
 	}
 
 	executionResult := types.PerformerActionData{

--- a/internal/keeper/core/execution/executor.go
+++ b/internal/keeper/core/execution/executor.go
@@ -20,12 +20,18 @@ import (
 	"github.com/trigg3rX/triggerx-backend/pkg/types"
 )
 
+// TaskMonitorClientInterface defines the interface for taskmonitor client operations
+type TaskMonitorClientInterface interface {
+	ReportTaskError(ctx context.Context, taskID int64, errorMsg string) error
+}
+
 // TaskExecutor is the default implementation of TaskExecutor
 type TaskExecutor struct {
 	alchemyAPIKey    string
 	argConverter     *ArgumentConverter
 	validator        *validation.TaskValidator
 	aggregatorClient *aggregator.AggregatorClient
+	taskMonitorClient TaskMonitorClientInterface
 	logger           logging.Logger
 	nonceManagers    map[string]*NonceManager // Chain ID -> NonceManager
 	nonceMutex       sync.RWMutex
@@ -36,12 +42,14 @@ func NewTaskExecutor(
 	alchemyAPIKey string,
 	validator *validation.TaskValidator,
 	aggregatorClient *aggregator.AggregatorClient,
+	taskMonitorClient TaskMonitorClientInterface,
 	logger logging.Logger) *TaskExecutor {
 	return &TaskExecutor{
 		alchemyAPIKey:    alchemyAPIKey,
 		argConverter:     &ArgumentConverter{},
 		validator:        validator,
 		aggregatorClient: aggregatorClient,
+		taskMonitorClient: taskMonitorClient,
 		logger:           logger,
 		nonceManagers:    make(map[string]*NonceManager),
 	}
@@ -134,6 +142,8 @@ func (e *TaskExecutor) ExecuteTask(ctx context.Context, task *types.SendTaskData
 			actionData, err = e.executeAction(&task.TargetData[idx], &task.TriggerData[idx], nonce, client)
 			if err != nil {
 				e.logger.Error("Failed to execute action", "task_id", task.TaskID, "trace_id", traceID, "error", err)
+				// Report error to taskmonitor
+				e.reportTaskError(task.TargetData[idx].TaskID, fmt.Sprintf("action execution failed: %v", err))
 				resultCh <- struct {
 					success bool
 					err     error
@@ -210,6 +220,8 @@ func (e *TaskExecutor) ExecuteTask(ctx context.Context, task *types.SendTaskData
 			cid, err := e.validator.IpfsClient.Upload(ctx, filename, ipfsDataBytes)
 			if err != nil {
 				e.logger.Error("Failed to upload IPFS data", "task_id", task.TaskID, "trace_id", traceID, "error", err)
+				// Report error to taskmonitor
+				e.reportTaskError(task.TargetData[idx].TaskID, fmt.Sprintf("IPFS upload failed: %v", err))
 				resultCh <- struct {
 					success bool
 					err     error
@@ -228,6 +240,12 @@ func (e *TaskExecutor) ExecuteTask(ctx context.Context, task *types.SendTaskData
 			success, err := e.aggregatorClient.SendTaskToValidators(ctx, &aggregatorData)
 			if !success {
 				e.logger.Error("Failed to send task result to aggregator", "task_id", task.TaskID, "error", err, "trace_id", traceID)
+				// Report error to taskmonitor
+				errorMsg := "failed to send task result to aggregator"
+				if err != nil {
+					errorMsg = fmt.Sprintf("%s: %v", errorMsg, err)
+				}
+				e.reportTaskError(task.TargetData[idx].TaskID, errorMsg)
 				resultCh <- struct {
 					success bool
 					err     error
@@ -282,6 +300,27 @@ func (e *TaskExecutor) getNonceManager(chainID string) (*NonceManager, error) {
 
 	e.nonceManagers[chainID] = nm
 	return nm, nil
+}
+
+// reportTaskError reports a task error to taskmonitor (best-effort, doesn't block)
+func (e *TaskExecutor) reportTaskError(taskID int64, errorMsg string) {
+	if e.taskMonitorClient == nil {
+		e.logger.Debug("TaskMonitor client not available, skipping error report",
+			"task_id", taskID)
+		return
+	}
+
+	// Report error asynchronously to avoid blocking
+	go func() {
+		reportCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := e.taskMonitorClient.ReportTaskError(reportCtx, taskID, errorMsg); err != nil {
+			e.logger.Warn("Failed to report task error to taskmonitor",
+				"task_id", taskID,
+				"error", err)
+		}
+	}()
 }
 
 // func parseStringToInt(str string) int {

--- a/internal/keeper/core/execution/nonce_manager.go
+++ b/internal/keeper/core/execution/nonce_manager.go
@@ -191,7 +191,7 @@ func (nm *NonceManager) submitNewTransaction(
 		return nil, "", fmt.Errorf("gas price is required for transaction")
 	}
 
-	tx := types.NewTransaction(nonce, to, big.NewInt(0), 300000, gasPrice, data)
+	tx := types.NewTransaction(nonce, to, big.NewInt(0), 600000, gasPrice, data)
 	signedTx, signErr := types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
 	if signErr != nil {
 		return nil, "", fmt.Errorf("failed to sign transaction: %w", signErr)
@@ -226,7 +226,7 @@ func (nm *NonceManager) replaceTransaction(
 	gasPrice = new(big.Int).Div(gasPrice, big.NewInt(100))
 
 	// Create legacy replacement transaction
-	tx := types.NewTransaction(existingTx.Nonce, to, big.NewInt(0), 300000, gasPrice, data)
+	tx := types.NewTransaction(existingTx.Nonce, to, big.NewInt(0), 600000, gasPrice, data)
 	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to sign replacement transaction: %w", err)
@@ -376,7 +376,7 @@ func (nm *NonceManager) createReplacementTransaction(originalTx *types.Transacti
 	gasPrice.Div(gasPrice, feeDivisor)
 
 	// Create and sign the replacement transaction
-	tx := types.NewTransaction(originalTx.Nonce(), to, big.NewInt(0), 300000, gasPrice, data)
+	tx := types.NewTransaction(originalTx.Nonce(), to, big.NewInt(0), 600000, gasPrice, data)
 	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign replacement transaction: %w", err)

--- a/internal/keeper/core/validation/action.go
+++ b/internal/keeper/core/validation/action.go
@@ -10,16 +10,15 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/trigg3rX/triggerx-backend/internal/keeper/utils"
-	"github.com/trigg3rX/triggerx-backend/pkg/logging"
 	"github.com/trigg3rX/triggerx-backend/pkg/retry"
 	"github.com/trigg3rX/triggerx-backend/pkg/types"
 )
 
-const timeTolerance = 5 * time.Second
-const expirationTimeTolerance = 8 * time.Second
+const timeTolerance = 8 * time.Second
+const expirationTimeTolerance = 11 * time.Second
 
 // getReceiptRetryConfig returns a retry configuration optimized for L2 chains
-func getReceiptRetryConfig(logger logging.Logger) *retry.RetryConfig {
+func getReceiptRetryConfig() *retry.RetryConfig {
 	return &retry.RetryConfig{
 		MaxRetries:      12,                     // Very aggressive for receipt fetching
 		InitialDelay:    300 * time.Millisecond, // Start with 300ms
@@ -80,7 +79,7 @@ func (v *TaskValidator) ValidateAction(targetData *types.TaskTargetData, trigger
 	txHash := common.HexToHash(actionData.ActionTxHash)
 
 	// Get retry configuration
-	retryConfig := getReceiptRetryConfig(v.logger)
+	retryConfig := getReceiptRetryConfig()
 
 	// Try to get transaction receipt with retry logic
 	receiptOperation := func() (*ethtypes.Receipt, error) {

--- a/internal/taskmonitor/clients/database/queries/task.go
+++ b/internal/taskmonitor/clients/database/queries/task.go
@@ -42,7 +42,7 @@ const (
         SELECT email_id 
         FROM triggerx.user_data 
         WHERE user_id = ?`
-        GetTaskStatusByID = `
+	GetTaskStatusByID = `
         SELECT task_status
         FROM triggerx.task_data
         WHERE task_id = ?`
@@ -67,6 +67,12 @@ const (
         UPDATE triggerx.task_data 
         SET is_successful = false,
             task_status = 'failed'
+        WHERE task_id = ?`
+	UpdateTaskError = `
+        UPDATE triggerx.task_data 
+        SET is_successful = false,
+            task_status = 'failed',
+            task_error = ?
         WHERE task_id = ?`
 	UpdateAttesterPointsAndNoOfTasks = `
         UPDATE triggerx.keeper_data 

--- a/internal/taskmonitor/config/config.go
+++ b/internal/taskmonitor/config/config.go
@@ -90,7 +90,7 @@ func Init() error {
 	}
 	cfg = Config{
 		devMode:                      env.GetEnvBool("DEV_MODE", false),
-		taskMonitorRPCPort:           env.GetEnvString("TASK_MONITOR_RPC_PORT", "9003"),
+		taskMonitorRPCPort:           env.GetEnvString("TASK_MONITOR_RPC_PORT", "9007"),
 		attestationCenterAddress:     env.GetEnvString("ATTESTATION_CENTER_ADDRESS", ""),
 		testAttestationCenterAddress: env.GetEnvString("TEST_ATTESTATION_CENTER_ADDRESS", ""),
 		rpcProvider:                  env.GetEnvString("RPC_PROVIDER", ""),

--- a/internal/taskmonitor/rpc/handler.go
+++ b/internal/taskmonitor/rpc/handler.go
@@ -1,0 +1,127 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/trigg3rX/triggerx-backend/internal/taskmonitor/types"
+	"github.com/trigg3rX/triggerx-backend/pkg/cryptography"
+	"github.com/trigg3rX/triggerx-backend/pkg/logging"
+	rpcpkg "github.com/trigg3rX/triggerx-backend/pkg/rpc"
+)
+
+// TaskMonitorHandler implements the generic RPC handler interface
+type TaskMonitorHandler struct {
+	logger  logging.Logger
+	monitor TaskMonitorInterface
+}
+
+// TaskMonitorInterface defines the interface for task monitor operations
+type TaskMonitorInterface interface {
+	ReportTaskError(ctx context.Context, req *types.ReportTaskErrorRequest) (*types.ReportTaskErrorResponse, error)
+}
+
+// NewTaskMonitorHandler creates a new RPC handler
+func NewTaskMonitorHandler(logger logging.Logger, monitor TaskMonitorInterface) *TaskMonitorHandler {
+	return &TaskMonitorHandler{
+		logger:  logger,
+		monitor: monitor,
+	}
+}
+
+// Handle routes incoming RPC requests based on the method name
+func (h *TaskMonitorHandler) Handle(ctx context.Context, method string, request interface{}) (interface{}, error) {
+	switch method {
+	case "report-task-error":
+		// Convert request to the expected type
+		req, ok := request.(*types.ReportTaskErrorRequest)
+		if !ok {
+			// Try to convert from map if it's JSON-decoded
+			if reqMap, ok := request.(map[string]interface{}); ok {
+				var err error
+				req, err = h.convertMapToRequest(reqMap)
+				if err != nil {
+					return nil, fmt.Errorf("failed to convert request: %w", err)
+				}
+			} else {
+				return nil, fmt.Errorf("invalid request type for report-task-error: %T", request)
+			}
+		}
+
+		// Validate keeper signature
+		if err := h.validateSignature(req); err != nil {
+			h.logger.Error("Invalid keeper signature for task error report",
+				"task_id", req.TaskID,
+				"keeper_address", req.KeeperAddress,
+				"error", err)
+			return nil, fmt.Errorf("invalid signature: %w", err)
+		}
+
+		resp, err := h.monitor.ReportTaskError(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return resp, nil
+
+	default:
+		return nil, fmt.Errorf("unknown method: %s", method)
+	}
+}
+
+// GetMethods advertises the supported RPC methods for discovery/metrics
+func (h *TaskMonitorHandler) GetMethods() []rpcpkg.RPCMethod {
+	return []rpcpkg.RPCMethod{
+		{
+			Name:         "report-task-error",
+			Description:  "Report a task execution error from a keeper",
+			RequestType:  &types.ReportTaskErrorRequest{},
+			ResponseType: &types.ReportTaskErrorResponse{},
+			Timeout:      30 * time.Second,
+		},
+	}
+}
+
+// convertMapToRequest converts a map to ReportTaskErrorRequest
+// This is used when the request comes as JSON-decoded map
+func (h *TaskMonitorHandler) convertMapToRequest(reqMap map[string]interface{}) (*types.ReportTaskErrorRequest, error) {
+	// Convert map back to JSON and then unmarshal to proper struct
+	jsonData, err := json.Marshal(reqMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request map: %w", err)
+	}
+
+	var req types.ReportTaskErrorRequest
+	if err := json.Unmarshal(jsonData, &req); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal request: %w", err)
+	}
+
+	return &req, nil
+}
+
+// validateSignature validates the keeper's signature for the error report
+func (h *TaskMonitorHandler) validateSignature(req *types.ReportTaskErrorRequest) error {
+	// Create a struct for signing (without signature field)
+	signData := struct {
+		TaskID        int64  `json:"task_id"`
+		KeeperAddress string `json:"keeper_address"`
+		Error         string `json:"error"`
+	}{
+		TaskID:        req.TaskID,
+		KeeperAddress: req.KeeperAddress,
+		Error:         req.Error,
+	}
+
+	// Verify signature using JSON verification (same as other services)
+	isValid, err := cryptography.VerifySignatureFromJSON(signData, req.Signature, req.KeeperAddress)
+	if err != nil {
+		return fmt.Errorf("signature verification failed: %w", err)
+	}
+
+	if !isValid {
+		return fmt.Errorf("invalid signature for keeper %s", req.KeeperAddress)
+	}
+
+	return nil
+}

--- a/internal/taskmonitor/rpc/server.go
+++ b/internal/taskmonitor/rpc/server.go
@@ -1,0 +1,38 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/trigg3rX/triggerx-backend/pkg/logging"
+	rpcserver "github.com/trigg3rX/triggerx-backend/pkg/rpc/server"
+)
+
+// StartRPCServer creates and starts the Task Monitor gRPC server using the generic approach.
+// It registers the task monitor handler with the generic RPC server.
+func StartRPCServer(ctx context.Context, logger logging.Logger, monitor TaskMonitorInterface, addr string, portStr string) (*rpcserver.Server, error) {
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid port %q: %w", portStr, err)
+	}
+
+	srv := rpcserver.NewServer(rpcserver.Config{
+		Name:    "TaskMonitor",
+		Version: "1.0.0",
+		Address: addr,
+		Port:    port,
+	}, logger)
+
+	// Add useful middleware (logging)
+	srv.AddInterceptor(rpcserver.LoggingInterceptor(logger))
+
+	// Create and register the generic RPC handler
+	handler := NewTaskMonitorHandler(logger, monitor)
+	srv.RegisterHandler("TaskMonitor", handler)
+
+	if err := srv.Start(ctx); err != nil {
+		return nil, err
+	}
+	return srv, nil
+}

--- a/internal/taskmonitor/tasks/task_add.go
+++ b/internal/taskmonitor/tasks/task_add.go
@@ -65,6 +65,63 @@ func (tsm *TaskStreamManager) MarkTaskCompleted(ctx context.Context, taskID int6
 	return nil
 }
 
+// MarkTaskFailed marks a task as failed with an error message
+func (tsm *TaskStreamManager) MarkTaskFailed(ctx context.Context, taskID int64, errorMsg string) error {
+	tsm.logger.Info("Marking task as failed",
+		"task_id", taskID,
+		"error", errorMsg)
+
+	// Find task in dispatched stream
+	task, messageID, err := tsm.taskIndex.FindTaskByID(ctx, taskID)
+	if err != nil {
+		tsm.logger.Warn("Failed to find task in dispatched stream, may already be processed",
+			"task_id", taskID,
+			"error", err)
+		// Don't return error - task may have already been processed
+		return nil
+	}
+
+	// Move to failed stream
+	if err := tsm.moveTaskToFailed(ctx, *task, errorMsg); err != nil {
+		tsm.logger.Error("Failed to move task to failed stream",
+			"task_id", taskID,
+			"error", err)
+		return err
+	}
+
+	// Acknowledge the task if we have the messageID
+	if messageID != "" {
+		err := tsm.AckTaskProcessed(ctx, StreamTaskDispatched, "task-processors", messageID)
+		if err != nil {
+			tsm.logger.Error("Failed to acknowledge failed task",
+				"task_id", taskID,
+				"message_id", messageID,
+				"error", err)
+		} else {
+			// Remove the task from the index since it's been processed
+			err = tsm.taskIndex.RemoveTaskIndex(ctx, taskID)
+			if err != nil {
+				tsm.logger.Warn("failed to remove failed task from index",
+					"task_id", taskID,
+					"error", err)
+			}
+
+			// Remove the task from timeout tracking since it's been failed
+			err = tsm.timeoutManager.RemoveTaskTimeout(ctx, taskID)
+			if err != nil {
+				tsm.logger.Warn("failed to remove failed task from timeout tracking",
+					"task_id", taskID,
+					"error", err)
+			}
+		}
+	}
+
+	tsm.logger.Info("Task marked as failed successfully", "task_id", taskID)
+	metrics.TasksAddedToStreamTotal.WithLabelValues("failed", "success").Inc()
+
+	return nil
+}
+
 // findTaskInDispatched finds a specific task in the dispatched stream
 func (tsm *TaskStreamManager) findTaskInDispatched(taskID int64) (*TaskStreamData, error) {
 	ctx := context.Background()

--- a/internal/taskmonitor/types/task_error.go
+++ b/internal/taskmonitor/types/task_error.go
@@ -1,0 +1,15 @@
+package types
+
+// ReportTaskErrorRequest represents a request to report a task error from a keeper
+type ReportTaskErrorRequest struct {
+	TaskID        int64  `json:"task_id" validate:"required"`
+	KeeperAddress string `json:"keeper_address" validate:"required"`
+	Error         string `json:"error" validate:"required"`
+	Signature     string `json:"signature" validate:"required"`
+}
+
+// ReportTaskErrorResponse represents the response to a task error report
+type ReportTaskErrorResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+}

--- a/pkg/client/dbserver/time.go
+++ b/pkg/client/dbserver/time.go
@@ -36,6 +36,8 @@ func (c *DBServerClient) GetTimeBasedTasks(ctx context.Context) ([]types.Schedul
 		return nil, fmt.Errorf("failed to unmarshal response body: %v", err)
 	}
 
-	c.logger.Debugf("Fetched %d time-based tasks", len(tasks))
+	if len(tasks) != 0 {
+		c.logger.Debugf("Fetched %d time-based tasks", len(tasks))
+	}
 	return tasks, nil
 }

--- a/pkg/dockerexecutor/execution/monitor.go
+++ b/pkg/dockerexecutor/execution/monitor.go
@@ -82,7 +82,7 @@ func (em *executionMonitor) startMonitoring() {
 }
 
 func (em *executionMonitor) performHealthCheck() {
-	em.logger.Debugf("Performing health check")
+	// em.logger.Debugf("Performing health check")
 
 	// Get monitoring configuration
 	monitoringConfig := em.config.GetMonitoringConfig()

--- a/pkg/types/database_models.go
+++ b/pkg/types/database_models.go
@@ -143,6 +143,7 @@ type TaskData struct {
 	TaSignature          []byte    `json:"ta_signature"`
 	TaskSubmissionTxHash string    `json:"task_submission_tx_hash"`
 	TaskStatus           string    `json:"task_status"`
+	TaskError            string    `json:"task_error"`
 	IsAccepted           bool      `json:"is_accepted"`
 	IsImua               bool      `json:"is_imua"`
 }

--- a/scripts/create-job.sh
+++ b/scripts/create-job.sh
@@ -5,6 +5,58 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 
+PRIVATE_KEY=
+CHAIN_ID=421614
+JOB_REGISTRY_CONTRACT_ADDRESS=0x476ACc7949a95e31144cC84b8F6BC7abF0967E4b
+TEST_CONTRACT_ADDRESS=0xa92f95FDeF3DB6B2aA115548376c7a2429711497
+ALCHEMY_API_KEY=
+RPC_URL=https://arb-sepolia.g.alchemy.com/v2/$ALCHEMY_API_KEY
+IPFS_URL=https://teal-random-koala-993.mypinata.cloud/ipfs/bafkreif426p7t7takzhw3g6we2h6wsvf27p5jxj3gaiynqf22p3jvhx4la
+
+read -r -d '' TEST_EVENT_ABI <<'EOF'
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "previousValue",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newValue",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "incrementAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "CounterIncremented",
+    "type": "event"
+  }
+]
+EOF
+
+read -r -d '' TEST_FUNCTION_ABI <<'EOF'
+[
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "incrementBy",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]
+EOF
+
 TASK_DEFINITION_ID=$1
 
 if ! [[ "$TASK_DEFINITION_ID" =~ ^[1-6]$ ]]; then
@@ -16,8 +68,10 @@ adj=$(shuf -n 1 scripts/adjectives.txt)
 noun=$(shuf -n 1 scripts/nouns.txt)
 
 JOB_TITLE="$adj $noun"
-
-JOB_ID=$(date +%s)
+RECURRING=false
+JOB_DATA=""
+DYNAMIC_ARGUMENTS_SCRIPT_URL=""
+JOB_DATA=$(printf '0x%064x' 1)
 
 case $TASK_DEFINITION_ID in
   1)
@@ -25,7 +79,6 @@ case $TASK_DEFINITION_ID in
     TIME_FRAME=35
     TIME_INTERVAL=32
     ARG_TYPE=1
-    DYNAMIC_ARGUMENTS_SCRIPT_URL=
     echo "Creating Time-based Static Args Job..."
     ;;
   2)
@@ -33,7 +86,7 @@ case $TASK_DEFINITION_ID in
     TIME_FRAME=35
     TIME_INTERVAL=32
     ARG_TYPE=2
-    DYNAMIC_ARGUMENTS_SCRIPT_URL="https://teal-random-koala-993.mypinata.cloud/ipfs/bafkreif426p7t7takzhw3g6we2h6wsvf27p5jxj3gaiynqf22p3jvhx4la"
+    DYNAMIC_ARGUMENTS_SCRIPT_URL=$IPFS_URL
     echo "Creating Time-based Dynamic Args Job..."
     ;;
   3)
@@ -41,7 +94,6 @@ case $TASK_DEFINITION_ID in
     TIME_FRAME=2500
     TIME_INTERVAL=0
     ARG_TYPE=1
-    DYNAMIC_ARGUMENTS_SCRIPT_URL=
     echo "Creating Event-based Static Args Job..."
     ;;
   4)
@@ -49,7 +101,7 @@ case $TASK_DEFINITION_ID in
     TIME_FRAME=2500
     TIME_INTERVAL=0
     ARG_TYPE=2
-    DYNAMIC_ARGUMENTS_SCRIPT_URL="https://teal-random-koala-993.mypinata.cloud/ipfs/bafkreif426p7t7takzhw3g6we2h6wsvf27p5jxj3gaiynqf22p3jvhx4la"
+    DYNAMIC_ARGUMENTS_SCRIPT_URL=$IPFS_URL
     echo "Creating Event-based Dynamic Args Job..."
     ;;
   5)
@@ -57,7 +109,6 @@ case $TASK_DEFINITION_ID in
     TIME_FRAME=20
     TIME_INTERVAL=0
     ARG_TYPE=1
-    DYNAMIC_ARGUMENTS_SCRIPT_URL=
     echo "Creating Condition-based Static Args Job..."
     ;;
   6)
@@ -65,35 +116,112 @@ case $TASK_DEFINITION_ID in
     TIME_FRAME=20
     TIME_INTERVAL=0
     ARG_TYPE=2
-    DYNAMIC_ARGUMENTS_SCRIPT_URL="https://teal-random-koala-993.mypinata.cloud/ipfs/bafkreif426p7t7takzhw3g6we2h6wsvf27p5jxj3gaiynqf22p3jvhx4la"
+    DYNAMIC_ARGUMENTS_SCRIPT_URL=$IPFS_URL
     echo "Creating Condition-based Dynamic Args Job..."
     ;;
 esac
 
+if ! command -v cast >/dev/null 2>&1; then
+  echo "Error: foundry 'cast' CLI is required"
+  exit 1
+fi
+
+if [ -n "$DYNAMIC_ARGUMENTS_SCRIPT_URL" ]; then
+  IPFS_HASH_BYTES32=$(cast keccak "$DYNAMIC_ARGUMENTS_SCRIPT_URL")
+  if [ $? -ne 0 ] || [ -z "$IPFS_HASH_BYTES32" ]; then
+    echo "Error: failed to hash dynamic arguments script URL"
+    exit 1
+  fi
+else
+  IPFS_HASH_BYTES32=""
+fi
+
+case $TASK_DEFINITION_ID in
+  1)
+    JOB_DATA=$(cast abi-encode "encode(uint256)" $TIME_INTERVAL)
+    ;;
+  2)
+    if [ -z "$IPFS_HASH_BYTES32" ]; then
+      echo "Error: dynamic arguments script URL required for job type 2"
+      exit 1
+    fi
+    JOB_DATA=$(cast abi-encode "encode(uint256,bytes32)" $TIME_INTERVAL $IPFS_HASH_BYTES32)
+    ;;
+  3|5)
+    JOB_DATA=$(cast abi-encode "encode(bool)" $RECURRING)
+    ;;
+  4|6)
+    if [ -z "$IPFS_HASH_BYTES32" ]; then
+      echo "Error: dynamic arguments script URL required for job type $TASK_DEFINITION_ID"
+      exit 1
+    fi
+    JOB_DATA=$(cast abi-encode "encode(bool,bytes32)" $RECURRING $IPFS_HASH_BYTES32)
+    ;;
+  *)
+    JOB_DATA=0x
+    ;;
+esac
+
+if [ $? -ne 0 ] || [ -z "$JOB_DATA" ]; then
+  echo "Error: failed to encode job data"
+  exit 1
+fi
 
 echo "\nCalling CreateJob() to TriggerXJobRegistry..."
 
-cast send \
-  --async \
-  --chain 84532 \
-  --rpc-url https://base-sepolia.g.alchemy.com/v2/PIUHuKF0BQoK9ibzzDH-B-bk0LbiYY38 \
-  --private-key 2212ec53a0dddee799b3342a86bb45fd1192a1981139244869102be2b3c47045 \
-  0xdB66c11221234C6B19cCBd29868310c31494C21C \
-  "createJob(string,uint8,uint256,address,bytes)" test $TASK_DEFINITION_ID $TIME_FRAME 0x49a81A591afdDEF973e6e49aaEa7d76943ef234C 0x01 \
-  -- --broadcast
+EVENT_SIGNATURE=0x737fc62fbb05dd9fb7c799e68796a2d7c8324e310af7b656c0580e7b3cf8bf8a
+
+echo "Submitting transaction..."
+
+CAST_RESULT=$(cast send \
+  --chain $CHAIN_ID \
+  --rpc-url $RPC_URL \
+  --private-key $PRIVATE_KEY \
+  --json \
+  $JOB_REGISTRY_CONTRACT_ADDRESS \
+  "createJob(string,uint8,uint256,address,bytes)" "$JOB_TITLE" $TASK_DEFINITION_ID $TIME_FRAME $TEST_CONTRACT_ADDRESS $JOB_DATA)
+
+if [ $? -ne 0 ]; then
+  echo "Error: failed to submit transaction"
+  exit 1
+fi
+
+TX_HASH=$(echo "$CAST_RESULT" | jq -r '.transactionHash // empty')
+
+if [ -z "$TX_HASH" ]; then
+  echo "Error: unable to extract transaction hash"
+  exit 1
+fi
+
+echo "Transaction hash: $TX_HASH"
+
+JOB_ID_HEX=$(echo "$CAST_RESULT" | jq -r --arg sig "$EVENT_SIGNATURE" '.logs[] | select((.topics[0] | ascii_downcase) == ($sig | ascii_downcase)) | .topics[1]' | head -n 1)
+
+if [ -z "$JOB_ID_HEX" ]; then
+  RECEIPT=$(cast receipt "$TX_HASH" --rpc-url $RPC_URL --json)
+  JOB_ID_HEX=$(echo "$RECEIPT" | jq -r --arg sig "$EVENT_SIGNATURE" '.logs[] | select((.topics[0] | ascii_downcase) == ($sig | ascii_downcase)) | .topics[1]' | head -n 1)
+fi
+
+if [ -z "$JOB_ID_HEX" ]; then
+  echo "Error: unable to extract JobCreated event from logs"
+  exit 1
+fi
+
+JOB_ID=$(cast --to-dec "$JOB_ID_HEX")
+
+echo "Job created with ID: $JOB_ID"
 
 sleep 3
 
-# curl -X POST https://data.triggerx.network/api/jobs \ 192.168.1.56
 curl -X POST http://localhost:9002/api/jobs \
   -H "Content-Type: application/json" \
   -H "X-API-KEY: ADMIN" \
   -d "[
     {
-      \"user_address\": \"0x7Db951c0E6D8906687B459427eA3F3F2b456473B\",
+      \"user_address\": \"0x7db951c0e6d8906687b459427ea3f3f2b456473b\",
       \"ether_balance\": 50000000000000000,
       \"token_balance\": 50000000000000000000,
-      \"created_chain_id\": \"421614\",
+      \"created_chain_id\": \"$CHAIN_ID\",
       \"job_id\": \"$JOB_ID\",
       \"job_title\": \"$JOB_TITLE\",
       \"task_definition_id\": $TASK_DEFINITION_ID,
@@ -107,7 +235,7 @@ curl -X POST http://localhost:9002/api/jobs \
       \"cron_expression\": \"0 0 * * *\",
       \"specific_schedule\": \"2025-01-01 00:00:00\",
       \"trigger_chain_id\": \"421614\",
-      \"trigger_contract_address\": \"0x980B62Da83eFf3D4576C647993b0c1D7faf17c73\",
+      \"trigger_contract_address\": \"$TEST_CONTRACT_ADDRESS\",
       \"trigger_event\": \"Transfer(address,address,uint256)\",
       \"event_filter_para_name\": \"to\",
       \"event_filter_value\": \"0xC9dC9c361c248fFA0890d7E1a263247670914980\",
@@ -117,13 +245,13 @@ curl -X POST http://localhost:9002/api/jobs \
       \"value_source_type\": \"api\",
       \"value_source_url\": \"http://localhost:8080/price\",
       \"target_chain_id\": \"421614\",
-      \"target_contract_address\": \"0x980B62Da83eFf3D4576C647993b0c1D7faf17c73\",
+      \"target_contract_address\": \"$TEST_CONTRACT_ADDRESS\",
       \"target_function\": \"implementation\",
       \"abi\": \"[{\\\"inputs\\\":[],\\\"name\\\":\\\"implementation\\\",\\\"outputs\\\":[{\\\"internalType\\\":\\\"address\\\",\\\"name\\\":\\\"implementation_\\\",\\\"type\\\":\\\"address\\\"}],\\\"stateMutability\\\":\\\"nonpayable\\\",\\\"type\\\":\\\"function\\\"}]\",
       \"arg_type\": $ARG_TYPE,
       \"is_imua\": false,
       \"arguments\": [\"3\"],
-      \"created_chain_id\": \"421614\",
+      \"created_chain_id\": \"$CHAIN_ID\",
       \"dynamic_arguments_script_url\": \"$DYNAMIC_ARGUMENTS_SCRIPT_URL\"
     }
   ]"
@@ -136,10 +264,10 @@ if [ $TASK_DEFINITION_ID -eq 3 ] || [ $TASK_DEFINITION_ID -eq 4 ]; then
 
   cast send \
     --async \
-    --chain 421614 \
-    --rpc-url https://arb-sepolia.g.alchemy.com/v2/PIUHuKF0BQoK9ibzzDH-B-bk0LbiYY38 \
-    --private-key 2212ec53a0dddee799b3342a86bb45fd1192a1981139244869102be2b3c47045 \
-    0x980B62Da83eFf3D4576C647993b0c1D7faf17c73 "increment()" \
+    --chain $CHAIN_ID \
+    --rpc-url https://arb-sepolia.g.alchemy.com/v2/$ALCHEMY_API_KEY \
+    --private-key $PRIVATE_KEY \
+    $TEST_CONTRACT_ADDRESS "increment()" \
     -- --broadcast
 fi
 

--- a/scripts/database/init-db.cql
+++ b/scripts/database/init-db.cql
@@ -144,6 +144,7 @@ CREATE TABLE IF NOT EXISTS task_data (
     task_id bigint,
     task_number bigint,
     task_status text,
+    task_error text,
     job_id varint,
     task_definition_id int,
     created_at timestamp,


### PR DESCRIPTION
# Pull Request

## Description
This PR introduces the update to allow the performer to update the Task Monitor service in case of error in any of the following events:
1. Error in task execution (fetching the dynamic arguments, parsing them, and making the contract call).
2. Upload the task to IPFS (signing and uploading)
3. Send the task to the Aggregator node to broadcast

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement

## Implementation Details
- Updated the Task Monitor to host a gRPC server with `RequestTaskError` method, which can be called by performers in the event of task execution failure. It verifies that the correct assigned performer is calling the update on the task.
- Added the gRPC client on the keepers, which shall call the Task Monitor when the 3 events mentioned above occur.
- Updated DB Server (API and Websockets) to include `task_error` when fetching any task data.

### Note
- The failure case where the performer fails to receive the task from the Aggregator node via the P2P network is still not covered and is handled when the task timeout is reached in the Redis task stream.

## Create Job script
The `scripts/create-job.sh` is updated to make the `createJob` contract call before making the API call, and will use the `JobId` emitted at the job creation event.